### PR TITLE
Update minimum Rust version to 1.67

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Install Rust (1.66 w/ clippy)
-      uses: dtolnay/rust-toolchain@1.66
+    - name: Install Rust (1.67 w/ clippy)
+      uses: dtolnay/rust-toolchain@1.67
       with:
           components: clippy
     - name: Install Rust (nightly w/ rustfmt)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 exclude = [".github", "CONTRIBUTING.md"]
 keywords = ["modal", "readline", "tui", "vim"]
 categories = ["command-line-interface", "text-editors"]
+rust-version = "1.67"
 
 [features]
 default = ["readline", "widgets"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # modalkit
 
-[![Build Status](https://github.com/ulyssa/modalkit/workflows/CI/badge.svg)](https://github.com/ulyssa/modalkit/actions?query=workflow%3ACI+)
+[![Build Status](https://github.com/ulyssa/modalkit/actions/workflows/ci.yml/badge.svg)](https://github.com/ulyssa/modalkit/actions?query=workflow%3ACI+)
 [![License: Apache 2.0](https://img.shields.io/crates/l/modalkit.svg?logo=apache)](https://crates.io/crates/modalkit)
 [![#modalkit:0x.badd.cafe](https://img.shields.io/badge/matrix-%23modalkit:0x.badd.cafe-blue)](https://matrix.to/#/#modalkit:0x.badd.cafe)
 [![Latest Version](https://img.shields.io/crates/v/modalkit.svg?logo=rust)](https://crates.io/crates/modalkit)


### PR DESCRIPTION
The newer ratatui from #120 requires at least Rust 1.67. I'm going to bump the MSRV. (I already did this for iamb in ulyssa/iamb#164.)