### PR TITLE
Convert EditContext trait into a struct

### DIFF
--- a/src/editing/application.rs
+++ b/src/editing/application.rs
@@ -51,7 +51,7 @@
 //! }
 //!
 //! impl ApplicationAction for CodeReviewAction {
-//!     fn is_edit_sequence<C: EditContext>(&self, _: &C) -> SequenceStatus {
+//!     fn is_edit_sequence(&self, _: &EditContext) -> SequenceStatus {
 //!         match self {
 //!             CodeReviewAction::Approve(..) => SequenceStatus::Break,
 //!             CodeReviewAction::Comment(..) => SequenceStatus::Break,
@@ -60,7 +60,7 @@
 //!         }
 //!     }
 //!
-//!     fn is_last_action<C: EditContext>(&self, _: &C) -> SequenceStatus {
+//!     fn is_last_action(&self, _: &EditContext) -> SequenceStatus {
 //!         match self {
 //!             CodeReviewAction::Approve(..) => SequenceStatus::Atom,
 //!             CodeReviewAction::Comment(..) => SequenceStatus::Atom,
@@ -69,7 +69,7 @@
 //!         }
 //!     }
 //!
-//!     fn is_last_selection<C: EditContext>(&self, _: &C) -> SequenceStatus {
+//!     fn is_last_selection(&self, _: &EditContext) -> SequenceStatus {
 //!         match self {
 //!             CodeReviewAction::Approve(..) => SequenceStatus::Ignore,
 //!             CodeReviewAction::Comment(..) => SequenceStatus::Ignore,
@@ -78,7 +78,7 @@
 //!         }
 //!     }
 //!
-//!     fn is_switchable<C: EditContext>(&self, _: &C) -> bool {
+//!     fn is_switchable(&self, _: &EditContext) -> bool {
 //!         match self {
 //!             CodeReviewAction::Approve(..) => false,
 //!             CodeReviewAction::Comment(..) => false,
@@ -170,36 +170,36 @@ use crate::{
 pub trait ApplicationAction: Clone + Debug + Eq + PartialEq + Send {
     /// Allows controlling how application-specific actions are included in
     /// [RepeatType::EditSequence](crate::editing::base::RepeatType::EditSequence).
-    fn is_edit_sequence<C: EditContext>(&self, ctx: &C) -> SequenceStatus;
+    fn is_edit_sequence(&self, ctx: &EditContext) -> SequenceStatus;
 
     /// Allows controlling how application-specific actions are included in
     /// [RepeatType::LastAction](crate::editing::base::RepeatType::LastAction).
-    fn is_last_action<C: EditContext>(&self, ctx: &C) -> SequenceStatus;
+    fn is_last_action(&self, ctx: &EditContext) -> SequenceStatus;
 
     /// Allows controlling how application-specific actions are included in
     /// [RepeatType::LastSelection](crate::editing::base::RepeatType::LastSelection).
-    fn is_last_selection<C: EditContext>(&self, ctx: &C) -> SequenceStatus;
+    fn is_last_selection(&self, ctx: &EditContext) -> SequenceStatus;
 
     /// Allows controlling whether an application-specific action can cause
     /// a buffer switch on an
     /// [EditError::WrongBuffer](crate::editing::action::EditError::WrongBuffer).
-    fn is_switchable<C: EditContext>(&self, ctx: &C) -> bool;
+    fn is_switchable(&self, ctx: &EditContext) -> bool;
 }
 
 impl ApplicationAction for () {
-    fn is_edit_sequence<C: EditContext>(&self, _: &C) -> SequenceStatus {
+    fn is_edit_sequence(&self, _: &EditContext) -> SequenceStatus {
         SequenceStatus::Break
     }
 
-    fn is_last_action<C: EditContext>(&self, _: &C) -> SequenceStatus {
+    fn is_last_action(&self, _: &EditContext) -> SequenceStatus {
         SequenceStatus::Ignore
     }
 
-    fn is_last_selection<C: EditContext>(&self, _: &C) -> SequenceStatus {
+    fn is_last_selection(&self, _: &EditContext) -> SequenceStatus {
         SequenceStatus::Ignore
     }
 
-    fn is_switchable<C: EditContext>(&self, _: &C) -> bool {
+    fn is_switchable(&self, _: &EditContext) -> bool {
         false
     }
 }

--- a/src/editing/base.rs
+++ b/src/editing/base.rs
@@ -13,7 +13,6 @@ use regex::Regex;
 
 use crate::{
     editing::application::ApplicationWindowId,
-    input::bindings::SequenceClass,
     util::{
         is_filename_char,
         is_filepath_char,
@@ -256,8 +255,6 @@ pub enum RepeatType {
     /// The last selection resize made in a buffer.
     LastSelection,
 }
-
-impl SequenceClass for RepeatType {}
 
 /// Specify a range within the text around the current cursor position.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1630,7 +1627,7 @@ impl<Cursor: Wrappable> Wrappable for ViewportContext<Cursor> {
 /// This context object wraps information used when calculating what text covered by cursor
 /// movements.
 #[non_exhaustive]
-pub struct CursorMovementsContext<'a, 'b, 'c, Cursor, C: EditContext> {
+pub struct CursorMovementsContext<'a, Cursor> {
     /// What operation this movement is being done as part of.
     ///
     /// Certain movements, like [MoveType::WordBegin], behave different depending on the action.
@@ -1638,21 +1635,17 @@ pub struct CursorMovementsContext<'a, 'b, 'c, Cursor, C: EditContext> {
 
     /// Information about the user's view of the text, since this impacts movements that rely on
     /// how the text is displayed, such as [MoveType::ScreenLine].
-    pub view: &'b ViewportContext<Cursor>,
+    pub view: &'a ViewportContext<Cursor>,
 
     /// The editing context contains information about the current [InsertStyle], as well as the
     /// user-supplied [Count].
-    pub context: &'c C,
+    pub context: &'a EditContext,
 }
 
 /// Trait for objects capable of calculating contextual offsets from a cursor.
-pub trait CursorMovements<Cursor, Context: EditContext> {
+pub trait CursorMovements<Cursor> {
     /// Calculate the position of the first word on the line of the provided cursor.
-    fn first_word(
-        &self,
-        cursor: &Cursor,
-        ctx: &CursorMovementsContext<'_, '_, '_, Cursor, Context>,
-    ) -> Cursor;
+    fn first_word(&self, cursor: &Cursor, ctx: &CursorMovementsContext<'_, Cursor>) -> Cursor;
 
     /// Calculate the position of the cursor after performing a movement.
     fn movement(
@@ -1660,7 +1653,7 @@ pub trait CursorMovements<Cursor, Context: EditContext> {
         cursor: &Cursor,
         movement: &MoveType,
         count: &Count,
-        ctx: &CursorMovementsContext<'_, '_, '_, Cursor, Context>,
+        ctx: &CursorMovementsContext<'_, Cursor>,
     ) -> Option<Cursor>;
 
     /// Calculate a cursor range from the given cursor to the location after performing the
@@ -1670,7 +1663,7 @@ pub trait CursorMovements<Cursor, Context: EditContext> {
         cursor: &Cursor,
         movement: &MoveType,
         count: &Count,
-        ctx: &CursorMovementsContext<'_, '_, '_, Cursor, Context>,
+        ctx: &CursorMovementsContext<'_, Cursor>,
     ) -> Option<EditRange<Cursor>>;
 
     /// Calculate a cursor range based on a given cursor position and a [RangeType].
@@ -1680,7 +1673,7 @@ pub trait CursorMovements<Cursor, Context: EditContext> {
         range: &RangeType,
         inclusive: bool,
         count: &Count,
-        ctx: &CursorMovementsContext<'_, '_, '_, Cursor, Context>,
+        ctx: &CursorMovementsContext<'_, Cursor>,
     ) -> Option<EditRange<Cursor>>;
 }
 

--- a/src/editing/buffer/complete.rs
+++ b/src/editing/buffer/complete.rs
@@ -6,7 +6,6 @@ use crate::editing::{
     application::ApplicationInfo,
     base::{CompletionDisplay, CompletionScope, CompletionSelection, WordStyle},
     completion::{complete_path, CompletionList},
-    context::EditContext,
     cursor::Adjustable,
     store::Store,
 };
@@ -52,16 +51,15 @@ where
     ) -> EditResult<EditInfo, I>;
 }
 
-impl<'a, 'b, C, I> CompletionActions<CursorGroupIdContext<'a, 'b, C>, I> for EditBuffer<I>
+impl<'a, I> CompletionActions<CursorGroupIdContext<'a>, I> for EditBuffer<I>
 where
-    C: EditContext,
     I: ApplicationInfo,
 {
     fn complete_auto(
         &mut self,
         selection: &CompletionSelection,
         display: &CompletionDisplay,
-        ctx: &CursorGroupIdContext<'a, 'b, C>,
+        ctx: &CursorGroupIdContext<'a>,
         store: &mut Store<I>,
     ) -> EditResult<EditInfo, I> {
         let gid = ctx.0;
@@ -115,7 +113,7 @@ where
         &mut self,
         selection: &CompletionSelection,
         display: &CompletionDisplay,
-        ctx: &CursorGroupIdContext<'a, 'b, C>,
+        ctx: &CursorGroupIdContext<'a>,
         store: &mut Store<I>,
     ) -> EditResult<EditInfo, I> {
         let gid = ctx.0;
@@ -169,7 +167,7 @@ where
         scope: &CompletionScope,
         selection: &CompletionSelection,
         display: &CompletionDisplay,
-        ctx: &CursorGroupIdContext<'a, 'b, C>,
+        ctx: &CursorGroupIdContext<'a>,
         store: &mut Store<I>,
     ) -> EditResult<EditInfo, I> {
         let gid = ctx.0;
@@ -232,7 +230,7 @@ where
         scope: &CompletionScope,
         selection: &CompletionSelection,
         display: &CompletionDisplay,
-        ctx: &CursorGroupIdContext<'a, 'b, C>,
+        ctx: &CursorGroupIdContext<'a>,
         store: &mut Store<I>,
     ) -> EditResult<EditInfo, I> {
         let gid = ctx.0;
@@ -353,7 +351,7 @@ mod tests {
         let mut ebuf = EditBuffer::new("".to_string());
         let gid = ebuf.create_group();
         let vwctx = ViewportContext::default();
-        let vctx = VimContext::<TestInfo>::default();
+        let vctx = EditContext::default();
         let mut store = Store::<TestInfo>::default();
         let prev = MoveDir1D::Previous;
         let next = MoveDir1D::Next;
@@ -441,7 +439,8 @@ mod tests {
         // create buffer with path to temporary directory.
         let path = tmp.path().as_os_str().to_string_lossy();
         let (mut ebuf, gid, vwctx, mut vctx, mut store) = mkfivestr(path.as_ref());
-        vctx.persist.insert = Some(InsertStyle::Insert);
+        vctx.insert_style = Some(InsertStyle::Insert);
+        vctx.last_column = true;
 
         // Move to end of line.
         ebuf.set_leader(gid, Cursor::new(0, 0));

--- a/src/editing/buffer/cursor.rs
+++ b/src/editing/buffer/cursor.rs
@@ -2,7 +2,7 @@ use crate::editing::{
     action::{EditInfo, EditResult},
     application::ApplicationInfo,
     base::{Count, CursorCloseTarget, CursorGroupCombineStyle, MoveDir1D, Register},
-    context::EditContext,
+    context::Resolve,
     store::Store,
 };
 
@@ -44,16 +44,15 @@ where
     ) -> EditResult<EditInfo, I>;
 }
 
-impl<'a, 'b, C, I> CursorActions<CursorGroupIdContext<'a, 'b, C>, Store<I>, I> for EditBuffer<I>
+impl<'a, I> CursorActions<CursorGroupIdContext<'a>, Store<I>, I> for EditBuffer<I>
 where
-    C: EditContext,
     I: ApplicationInfo,
 {
     fn cursor_rotate(
         &mut self,
         dir: MoveDir1D,
         count: &Count,
-        ctx: &CursorGroupIdContext<'a, 'b, C>,
+        ctx: &CursorGroupIdContext<'a>,
         _: &mut Store<I>,
     ) -> EditResult<EditInfo, I> {
         let off = ctx.2.resolve(count);
@@ -67,7 +66,7 @@ where
     fn cursor_close(
         &mut self,
         target: &CursorCloseTarget,
-        ctx: &CursorGroupIdContext<'a, 'b, C>,
+        ctx: &CursorGroupIdContext<'a>,
         _: &mut Store<I>,
     ) -> EditResult<EditInfo, I> {
         let gid = ctx.0;
@@ -80,7 +79,7 @@ where
     fn cursor_restore(
         &mut self,
         style: &CursorGroupCombineStyle,
-        ctx: &CursorGroupIdContext<'a, 'b, C>,
+        ctx: &CursorGroupIdContext<'a>,
         store: &mut Store<I>,
     ) -> EditResult<EditInfo, I> {
         let reg = ctx.2.get_register().unwrap_or(Register::UnnamedCursorGroup);
@@ -100,7 +99,7 @@ where
     fn cursor_save(
         &mut self,
         style: &CursorGroupCombineStyle,
-        ctx: &CursorGroupIdContext<'a, 'b, C>,
+        ctx: &CursorGroupIdContext<'a>,
         store: &mut Store<I>,
     ) -> EditResult<EditInfo, I> {
         let reg = ctx.2.get_register().unwrap_or(Register::UnnamedCursorGroup);
@@ -121,7 +120,7 @@ where
     fn cursor_split(
         &mut self,
         count: &Count,
-        ctx: &CursorGroupIdContext<'a, 'b, C>,
+        ctx: &CursorGroupIdContext<'a>,
         _: &mut Store<I>,
     ) -> EditResult<EditInfo, I> {
         let count = ctx.2.resolve(count);

--- a/src/editing/context.rs
+++ b/src/editing/context.rs
@@ -3,63 +3,245 @@
 //! ## Overview
 //!
 //! This module contains the contexts used by the editing buffer.
-use regex::Regex;
-
-use crate::input::InputContext;
-
 use super::action::EditAction;
 use super::base::*;
-
-/// Trait for context objects used during editing operations.
-pub trait EditContext:
-    InputContext
-    + Resolve<Specifier<Char>, Option<Char>>
-    + Resolve<Specifier<Mark>, Mark>
-    + Resolve<Specifier<EditAction>, EditAction>
-    + Resolve<Count, usize>
-{
-    /// Indicates where to leave the cursor after editing text.
-    fn get_cursor_end(&self) -> CursorEnd {
-        CursorEnd::Auto
-    }
-
-    /// Indicates a shape to be applied to an [EditAction].
-    fn get_target_shape(&self) -> Option<TargetShape>;
-
-    /// Indicates the style by which text should be inserted into the buffer.
-    fn get_insert_style(&self) -> Option<InsertStyle>;
-
-    /// Indicates whether it is okay to move the cursor into the last column of a line.
-    fn get_last_column(&self) -> bool;
-
-    /// Indicates which register yanked and deleted text should go to.
-    fn get_register(&self) -> Option<Register>;
-
-    /// Indicates whether should be appended to the target register when yanking or deleting text.
-    fn get_register_append(&self) -> bool;
-
-    /// Returns a regular expression to search for in the buffer.
-    ///
-    /// If the context doesn't specify a search regex, then consumers should fall back to using
-    /// the contents of [Register::LastSearch].
-    fn get_search_regex(&self) -> Option<Regex>;
-
-    /// Get the direction in which to search.
-    fn get_search_regex_dir(&self) -> MoveDir1D;
-
-    /// Returns a character to search for on the current line, and the direction in
-    /// which to search.
-    fn get_search_char(&self) -> Option<(MoveDir1D, bool, Char)>;
-
-    /// Returns a [character](Char) to use when performing an [EditAction::Replace] operation.
-    fn get_replace_char(&self) -> Option<Char>;
-
-    /// Whether to perform incremental searches while typing in the search bar.
-    fn is_search_incremental(&self) -> bool;
-}
 
 /// Trait for values that can be converted by the [EditContext].
 pub trait Resolve<T, R> {
     /// Use contextual information to convert a `T` into an `R`.
     fn resolve(&self, t: &T) -> R;
+}
+
+/// Context for editing operations.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EditContext {
+    pub(crate) operation: EditAction,
+    pub(crate) mark: Option<Mark>,
+    pub(crate) count: Option<usize>,
+    pub(crate) typed: Option<Char>,
+
+    pub(crate) cursor_end: CursorEnd,
+    pub(crate) target_shape: Option<TargetShape>,
+    pub(crate) insert_style: Option<InsertStyle>,
+    pub(crate) last_column: bool,
+    pub(crate) register: Option<Register>,
+    pub(crate) register_append: bool,
+    pub(crate) search_regex_dir: MoveDir1D,
+    pub(crate) search_char: Option<(MoveDir1D, bool, Char)>,
+    pub(crate) replace_char: Option<Char>,
+    pub(crate) search_incremental: bool,
+}
+
+impl Default for EditContext {
+    fn default() -> Self {
+        Self {
+            operation: EditAction::Motion,
+            mark: None,
+            count: None,
+            typed: None,
+
+            cursor_end: CursorEnd::Auto,
+            target_shape: None,
+            insert_style: None,
+            last_column: false,
+            register: None,
+            register_append: false,
+            search_regex_dir: MoveDir1D::Next,
+            search_char: None,
+            replace_char: None,
+            search_incremental: false,
+        }
+    }
+}
+
+impl EditContext {
+    /// Indicates where to leave the cursor after editing text.
+    pub fn get_cursor_end(&self) -> CursorEnd {
+        self.cursor_end
+    }
+
+    /// Indicates a shape to be applied to an [EditAction].
+    pub fn get_target_shape(&self) -> Option<TargetShape> {
+        self.target_shape
+    }
+
+    /// Indicates the style by which text should be inserted into the buffer.
+    pub fn get_insert_style(&self) -> Option<InsertStyle> {
+        self.insert_style
+    }
+
+    /// Indicates whether it is okay to move the cursor into the last column of a line.
+    pub fn get_last_column(&self) -> bool {
+        self.last_column
+    }
+
+    /// Indicates which register yanked and deleted text should go to.
+    pub fn get_register(&self) -> Option<Register> {
+        self.register.clone()
+    }
+
+    /// Indicates whether should be appended to the target register when yanking or deleting text.
+    pub fn get_register_append(&self) -> bool {
+        self.register_append
+    }
+
+    /// Get the direction in which to search.
+    pub fn get_search_regex_dir(&self) -> MoveDir1D {
+        self.search_regex_dir
+    }
+
+    /// Returns a character to search for on the current line, and the direction in
+    /// which to search.
+    pub fn get_search_char(&self) -> Option<(MoveDir1D, bool, Char)> {
+        self.search_char.clone()
+    }
+
+    /// Returns a [character](Char) to use when performing an [EditAction::Replace] operation.
+    pub fn get_replace_char(&self) -> Option<Char> {
+        self.replace_char.clone()
+    }
+
+    /// Whether to perform incremental searches while typing in the search bar.
+    pub fn is_search_incremental(&self) -> bool {
+        self.search_incremental
+    }
+}
+
+impl Resolve<Count, usize> for EditContext {
+    fn resolve(&self, count: &Count) -> usize {
+        match count {
+            Count::Contextual => self.count.unwrap_or(1),
+            Count::MinusOne => self.count.unwrap_or(0).saturating_sub(1),
+            Count::Exact(n) => *n,
+        }
+    }
+}
+
+impl Resolve<Specifier<Char>, Option<Char>> for EditContext {
+    fn resolve(&self, c: &Specifier<Char>) -> Option<Char> {
+        match c {
+            Specifier::Contextual => self.typed.clone(),
+            Specifier::Exact(c) => Some(c.clone()),
+        }
+    }
+}
+
+impl Resolve<Specifier<Mark>, Mark> for EditContext {
+    fn resolve(&self, mark: &Specifier<Mark>) -> Mark {
+        match mark {
+            Specifier::Contextual => self.mark.unwrap_or(Mark::LastJump),
+            Specifier::Exact(m) => *m,
+        }
+    }
+}
+
+impl Resolve<Specifier<EditAction>, EditAction> for EditContext {
+    fn resolve(&self, mark: &Specifier<EditAction>) -> EditAction {
+        match mark {
+            Specifier::Contextual => self.operation.clone(),
+            Specifier::Exact(a) => a.clone(),
+        }
+    }
+}
+
+/// Build a new [EditContext].
+#[derive(Default)]
+pub struct EditContextBuilder(EditContext);
+
+impl EditContextBuilder {
+    /// Finish building the [EditContext].
+    pub fn build(self) -> EditContext {
+        self.0
+    }
+
+    /// Set the [CursorEnd].
+    pub fn cursor_end(mut self, v: CursorEnd) -> Self {
+        self.0.cursor_end = v;
+        self
+    }
+
+    /// Set the [TargetShape].
+    pub fn target_shape(mut self, v: Option<TargetShape>) -> Self {
+        self.0.target_shape = v;
+        self
+    }
+
+    /// Set the [InsertStyle].
+    pub fn insert_style(mut self, v: Option<InsertStyle>) -> Self {
+        self.0.insert_style = v;
+        self
+    }
+
+    /// Set whether it's okay to move the cursor into the last column.
+    pub fn last_column(mut self, v: bool) -> Self {
+        self.0.last_column = v;
+        self
+    }
+
+    /// Set the [Register].
+    pub fn register(mut self, v: Option<Register>) -> Self {
+        self.0.register = v;
+        self
+    }
+
+    /// Set whether this operation should append contents to the register or replace the existing
+    /// ones.
+    pub fn register_append(mut self, v: bool) -> Self {
+        self.0.register_append = v;
+        self
+    }
+
+    /// Set the direction the regular expression should search in.
+    pub fn search_regex_dir(mut self, v: MoveDir1D) -> Self {
+        self.0.search_regex_dir = v;
+        self
+    }
+
+    /// Set a character to search for.
+    pub fn search_char(mut self, v: Option<(MoveDir1D, bool, Char)>) -> Self {
+        self.0.search_char = v;
+        self
+    }
+
+    /// Set a [Char] to replace existing characters with.
+    pub fn replace_char(mut self, v: Option<Char>) -> Self {
+        self.0.replace_char = v;
+        self
+    }
+
+    /// Set whether we should do an incremental search.
+    pub fn search_incremental(mut self, v: bool) -> Self {
+        self.0.search_incremental = v;
+        self
+    }
+
+    /// Set the contextual [Mark].
+    pub fn mark(mut self, mark: Option<Mark>) -> Self {
+        self.0.mark = mark;
+        self
+    }
+
+    /// Set the contextual [Mark].
+    pub fn typed_char(mut self, ch: Option<Char>) -> Self {
+        self.0.typed = ch;
+        self
+    }
+
+    /// Set the contextual [Mark].
+    pub fn operation(mut self, op: EditAction) -> Self {
+        self.0.operation = op;
+        self
+    }
+
+    /// Set the contextual count.
+    pub fn count(mut self, n: Option<usize>) -> Self {
+        self.0.count = n;
+        self
+    }
+}
+
+impl From<EditContext> for EditContextBuilder {
+    fn from(ctx: EditContext) -> Self {
+        EditContextBuilder(ctx)
+    }
 }

--- a/src/editing/store/mod.rs
+++ b/src/editing/store/mod.rs
@@ -12,7 +12,6 @@
 //! use modalkit::{
 //!     editing::application::EmptyInfo,
 //!     editing::store::{SharedStore, Store},
-//!     env::vim::VimContext,
 //! };
 //!
 //! let store: SharedStore<EmptyInfo> = Store::default().shared();

--- a/src/env/mixed.rs
+++ b/src/env/mixed.rs
@@ -6,42 +6,28 @@
 //! flavor of keybindings they want to use during or after program startup.
 use std::borrow::Cow;
 
-use regex::Regex;
-
 use crate::{
     editing::{
-        action::{Action, EditAction},
+        action::Action,
         application::{ApplicationInfo, EmptyInfo},
-        base::{
-            Char,
-            Count,
-            CursorEnd,
-            InsertStyle,
-            Mark,
-            MoveDir1D,
-            Register,
-            RepeatType,
-            Specifier,
-            TargetShape,
-        },
-        context::{EditContext, Resolve},
+        base::RepeatType,
+        context::EditContext,
     },
     input::{
         bindings::{BindingMachine, Step},
         dialog::Dialog,
         key::{InputKey, TerminalKey},
-        InputContext,
     },
 };
 
 use super::{
     emacs::{
         keybindings::{EmacsMachine, InputStep as EmacsStep},
-        EmacsContext,
+        EmacsState,
     },
     vim::{
         keybindings::{InputStep as VimStep, VimMachine},
-        VimContext,
+        VimState,
     },
 };
 
@@ -54,70 +40,6 @@ pub enum MixedChoice {
 
     /// Choose Vim keybindings.
     Vim,
-}
-
-/// Wrapper for the contexts used with different keybinding environments.
-#[allow(clippy::large_enum_variant)]
-pub enum MixedContext<I: ApplicationInfo = EmptyInfo> {
-    /// Wrapper for the Emacs context.
-    Emacs(EmacsContext<I>),
-
-    /// Wrapper for the Vim context.
-    Vim(VimContext<I>),
-}
-
-impl<I> Clone for MixedContext<I>
-where
-    I: ApplicationInfo,
-{
-    fn clone(&self) -> Self {
-        match self {
-            MixedContext::Emacs(c) => MixedContext::Emacs(c.clone()),
-            MixedContext::Vim(c) => MixedContext::Vim(c.clone()),
-        }
-    }
-}
-
-impl<I> Default for MixedContext<I>
-where
-    I: ApplicationInfo,
-{
-    fn default() -> Self {
-        panic!("Cannot create a default MixedContext")
-    }
-}
-
-impl<I> From<EmacsContext<I>> for MixedContext<I>
-where
-    I: ApplicationInfo,
-{
-    fn from(ctx: EmacsContext<I>) -> Self {
-        MixedContext::Emacs(ctx)
-    }
-}
-
-impl<I> From<VimContext<I>> for MixedContext<I>
-where
-    I: ApplicationInfo,
-{
-    fn from(ctx: VimContext<I>) -> Self {
-        MixedContext::Vim(ctx)
-    }
-}
-
-macro_rules! delegate_context {
-    ($s: expr, $invoke: expr) => {
-        match $s {
-            MixedContext::Emacs(c) => $invoke(c),
-            MixedContext::Vim(c) => $invoke(c),
-        }
-    };
-    ($s: expr, $invoke: expr, $arg: expr) => {
-        match $s {
-            MixedContext::Emacs(c) => $invoke(c, $arg),
-            MixedContext::Vim(c) => $invoke(c, $arg),
-        }
-    };
 }
 
 macro_rules! delegate_bindings {
@@ -139,109 +61,6 @@ macro_rules! delegate_bindings {
             MixedBindings::Vim(c) => $invoke(c, $arg1, $arg2),
         }
     };
-}
-
-impl<I> InputContext for MixedContext<I>
-where
-    I: ApplicationInfo,
-{
-    fn overrides(&mut self, other: &Self) {
-        match (self, other) {
-            (MixedContext::Emacs(e), MixedContext::Emacs(c)) => e.overrides(c),
-            (MixedContext::Vim(e), MixedContext::Vim(c)) => e.overrides(c),
-
-            (MixedContext::Emacs(_), _) => {
-                panic!("Must use MixedContext::Emacs with MixedContext::Emacs.overrides()!")
-            },
-            (MixedContext::Vim(_), _) => {
-                panic!("Must use MixedContext::Vim with MixedContext::Vim.overrides()!")
-            },
-        }
-    }
-
-    fn reset(&mut self) {
-        match self {
-            MixedContext::Emacs(c) => c.reset(),
-            MixedContext::Vim(c) => c.reset(),
-        }
-    }
-
-    fn take(&mut self) -> Self {
-        match self {
-            MixedContext::Emacs(c) => c.take().into(),
-            MixedContext::Vim(c) => c.take().into(),
-        }
-    }
-}
-
-impl<I: ApplicationInfo> Resolve<Count, usize> for MixedContext<I> {
-    fn resolve(&self, count: &Count) -> usize {
-        delegate_context!(self, Resolve::resolve, count)
-    }
-}
-
-impl<I: ApplicationInfo> Resolve<Specifier<Char>, Option<Char>> for MixedContext<I> {
-    fn resolve(&self, c: &Specifier<Char>) -> Option<Char> {
-        delegate_context!(self, Resolve::resolve, c)
-    }
-}
-
-impl<I: ApplicationInfo> Resolve<Specifier<EditAction>, EditAction> for MixedContext<I> {
-    fn resolve(&self, ea: &Specifier<EditAction>) -> EditAction {
-        delegate_context!(self, Resolve::resolve, ea)
-    }
-}
-
-impl<I: ApplicationInfo> Resolve<Specifier<Mark>, Mark> for MixedContext<I> {
-    fn resolve(&self, mark: &Specifier<Mark>) -> Mark {
-        delegate_context!(self, Resolve::resolve, mark)
-    }
-}
-
-impl<I: ApplicationInfo> EditContext for MixedContext<I> {
-    fn get_cursor_end(&self) -> CursorEnd {
-        delegate_context!(self, EditContext::get_cursor_end)
-    }
-
-    fn get_replace_char(&self) -> Option<Char> {
-        delegate_context!(self, EditContext::get_replace_char)
-    }
-
-    fn get_search_regex(&self) -> Option<Regex> {
-        delegate_context!(self, EditContext::get_search_regex)
-    }
-
-    fn get_search_regex_dir(&self) -> MoveDir1D {
-        delegate_context!(self, EditContext::get_search_regex_dir)
-    }
-
-    fn get_search_char(&self) -> Option<(MoveDir1D, bool, Char)> {
-        delegate_context!(self, EditContext::get_search_char)
-    }
-
-    fn get_target_shape(&self) -> Option<TargetShape> {
-        delegate_context!(self, EditContext::get_target_shape)
-    }
-
-    fn get_insert_style(&self) -> Option<InsertStyle> {
-        delegate_context!(self, EditContext::get_insert_style)
-    }
-
-    fn get_last_column(&self) -> bool {
-        delegate_context!(self, EditContext::get_last_column)
-    }
-
-    fn get_register(&self) -> Option<Register> {
-        delegate_context!(self, EditContext::get_register)
-    }
-
-    fn get_register_append(&self) -> bool {
-        delegate_context!(self, EditContext::get_register_append)
-    }
-
-    fn is_search_incremental(&self) -> bool {
-        delegate_context!(self, EditContext::is_search_incremental)
-    }
 }
 
 /// Type for wrapping different keybindings in contexts where keybindings can be determined
@@ -272,29 +91,23 @@ where
     }
 }
 
-impl<K, I> BindingMachine<K, Action<I>, RepeatType, MixedContext<I>> for MixedBindings<K, I>
+impl<K, I> BindingMachine<K, Action<I>, RepeatType, EditContext> for MixedBindings<K, I>
 where
     K: InputKey,
     I: ApplicationInfo,
-    EmacsStep<I>: Step<K, A = Action<I>, Sequence = RepeatType, C = EmacsContext<I>>,
-    VimStep<I>: Step<K, A = Action<I>, Sequence = RepeatType, C = VimContext<I>>,
+    EmacsStep<I>: Step<K, A = Action<I>, Sequence = RepeatType, C = EmacsState<I>>,
+    VimStep<I>: Step<K, A = Action<I>, Sequence = RepeatType, C = VimState<I>>,
 {
     fn input_key(&mut self, key: K) {
         delegate_bindings!(self, BindingMachine::input_key, key)
     }
 
-    fn pop(&mut self) -> Option<(Action<I>, MixedContext<I>)> {
-        match self {
-            MixedBindings::Emacs(e) => e.pop().map(|(a, c)| (a, c.into())),
-            MixedBindings::Vim(v) => v.pop().map(|(a, c)| (a, c.into())),
-        }
+    fn pop(&mut self) -> Option<(Action<I>, EditContext)> {
+        delegate_bindings!(self, BindingMachine::pop)
     }
 
-    fn context(&self) -> MixedContext<I> {
-        match self {
-            MixedBindings::Emacs(m) => m.context().into(),
-            MixedBindings::Vim(m) => m.context().into(),
-        }
+    fn context(&mut self) -> EditContext {
+        delegate_bindings!(self, BindingMachine::context)
     }
 
     fn show_dialog(&mut self, max_rows: usize, max_cols: usize) -> Vec<Cow<'_, str>> {
@@ -309,21 +122,8 @@ where
         delegate_bindings!(self, BindingMachine::get_cursor_indicator)
     }
 
-    fn repeat(&mut self, rt: RepeatType, other: Option<MixedContext<I>>) {
-        match (self, other) {
-            (MixedBindings::Emacs(m), Some(MixedContext::Emacs(c))) => m.repeat(rt, Some(c)),
-            (MixedBindings::Emacs(m), None) => m.repeat(rt, None),
-
-            (MixedBindings::Vim(m), Some(MixedContext::Vim(c))) => m.repeat(rt, Some(c)),
-            (MixedBindings::Vim(m), None) => m.repeat(rt, None),
-
-            (MixedBindings::Emacs(_), Some(_)) => {
-                panic!("Must use Emacs context with Emacs keybindings");
-            },
-            (MixedBindings::Vim(_), Some(_)) => {
-                panic!("Must use Vim context with Vim keybindings");
-            },
-        }
+    fn repeat(&mut self, rt: RepeatType, other: Option<EditContext>) {
+        delegate_bindings!(self, BindingMachine::repeat, rt, other)
     }
 
     fn run_dialog(&mut self, dialog: Box<dyn Dialog<Action<I>>>) {

--- a/src/input/commands.rs
+++ b/src/input/commands.rs
@@ -9,11 +9,7 @@ use std::str::FromStr;
 
 use radix_trie::Trie;
 
-use super::InputContext;
 use crate::util::completion_keys;
-
-/// Context passed to commands when they're executed.
-pub trait InputCmdContext: InputContext {}
 
 /// Result from executing a single command in a sequence.
 pub enum CommandStep<C: Command> {
@@ -69,10 +65,10 @@ pub trait Command: Clone {
     type Action;
 
     /// Context provided with each command string.
-    type Context: InputContext;
+    type Context;
 
     /// Context to be passed to [Command::exec].
-    type CommandContext: InputCmdContext + From<Self::Context>;
+    type CommandContext: From<Self::Context>;
 
     /// The primary name to map this command under.
     fn name(&self) -> String;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -10,13 +10,16 @@ pub mod dialog;
 pub mod key;
 
 /// Represents contextual information that is updated upon user input.
-pub trait InputContext: Clone + Default {
-    /// Override implementor-determined fields in this context using values from another.
-    fn overrides(&mut self, other: &Self);
+pub trait InputState: Clone + Default {
+    /// The output context type returned along with actions.
+    type Output: Clone + Default;
 
     /// Reset any action-specific state.
     fn reset(&mut self);
 
-    /// Return a copy of the InputContext, and reset any action-specific state.
-    fn take(&mut self) -> Self;
+    /// Return a copy of the InputState, and reset any action-specific state.
+    fn take(&mut self) -> Self::Output;
+
+    /// Copy any overriding values into an `Output` object.
+    fn merge(original: Self::Output, overrides: &Self::Output) -> Self::Output;
 }

--- a/src/readline/editor.rs
+++ b/src/readline/editor.rs
@@ -352,15 +352,14 @@ where
     }
 }
 
-impl<C, I> Editable<C, Store<I>, I> for Editor<I>
+impl<I> Editable<EditContext, Store<I>, I> for Editor<I>
 where
-    C: EditContext,
     I: ApplicationInfo,
 {
     fn editor_command(
         &mut self,
         act: &EditorAction,
-        ctx: &C,
+        ctx: &EditContext,
         store: &mut Store<I>,
     ) -> EditResult<EditInfo, I> {
         let ctx = (self.gid, &self.viewctx, ctx);
@@ -369,9 +368,8 @@ where
     }
 }
 
-impl<C, I> Jumpable<C, I> for Editor<I>
+impl<I> Jumpable<EditContext, I> for Editor<I>
 where
-    C: EditContext,
     I: ApplicationInfo,
 {
     fn jump(
@@ -379,7 +377,7 @@ where
         list: PositionList,
         dir: MoveDir1D,
         count: usize,
-        ctx: &C,
+        ctx: &EditContext,
     ) -> UIResult<usize, I> {
         let ctx = (self.gid, &self.viewctx, ctx);
 

--- a/src/widgets/cmdbar.rs
+++ b/src/widgets/cmdbar.rs
@@ -26,7 +26,7 @@ use crate::editing::{
     application::ApplicationInfo,
     base::{CommandType, Count, EditTarget, MoveDir1D, MoveDirMod, SearchType},
     completion::CompletionList,
-    context::EditContext,
+    context::{EditContext, Resolve},
     history::ScrollbackState,
     rope::EditRope,
     store::Store,
@@ -115,12 +115,15 @@ where
     }
 }
 
-impl<C, I> PromptActions<C, Store<I>, I> for CommandBarState<I>
+impl<I> PromptActions<EditContext, Store<I>, I> for CommandBarState<I>
 where
-    C: Default + EditContext,
     I: ApplicationInfo,
 {
-    fn submit(&mut self, ctx: &C, store: &mut Store<I>) -> EditResult<Vec<(Action<I>, C)>, I> {
+    fn submit(
+        &mut self,
+        ctx: &EditContext,
+        store: &mut Store<I>,
+    ) -> EditResult<Vec<(Action<I>, EditContext)>, I> {
         let unfocus = CommandBarAction::Unfocus.into();
 
         let action = match self.cmdtype {
@@ -151,9 +154,9 @@ where
     fn abort(
         &mut self,
         _empty: bool,
-        ctx: &C,
+        ctx: &EditContext,
         store: &mut Store<I>,
-    ) -> EditResult<Vec<(Action<I>, C)>, I> {
+    ) -> EditResult<Vec<(Action<I>, EditContext)>, I> {
         // We always unfocus currently, regardless of whether _empty=true.
         let act = Action::CommandBar(CommandBarAction::Unfocus);
 
@@ -176,9 +179,9 @@ where
         dir: &MoveDir1D,
         count: &Count,
         prefixed: bool,
-        ctx: &C,
+        ctx: &EditContext,
         store: &mut Store<I>,
-    ) -> EditResult<Vec<(Action<I>, C)>, I> {
+    ) -> EditResult<Vec<(Action<I>, EditContext)>, I> {
         let count = ctx.resolve(count);
         let rope = self.deref().get();
 
@@ -199,17 +202,16 @@ where
     }
 }
 
-impl<C, I> Promptable<C, Store<I>, I> for CommandBarState<I>
+impl<I> Promptable<EditContext, Store<I>, I> for CommandBarState<I>
 where
-    C: Default + EditContext,
     I: ApplicationInfo,
 {
     fn prompt(
         &mut self,
         act: &PromptAction,
-        ctx: &C,
+        ctx: &EditContext,
         store: &mut Store<I>,
-    ) -> EditResult<Vec<(Action<I>, C)>, I> {
+    ) -> EditResult<Vec<(Action<I>, EditContext)>, I> {
         match act {
             PromptAction::Abort(empty) => self.abort(*empty, ctx, store),
             PromptAction::Recall(dir, count, prefixed) => {

--- a/src/widgets/windows/mod.rs
+++ b/src/widgets/windows/mod.rs
@@ -29,7 +29,6 @@ use crate::editing::{
         WindowTarget,
         WriteFlags,
     },
-    context::EditContext,
     store::Store,
 };
 
@@ -227,7 +226,6 @@ pub(self) fn winnr_cmp(at: usize, lsize: usize, vsize: usize) -> (Ordering, usiz
 
 pub(super) trait WindowActions<C, I>
 where
-    C: EditContext,
     I: ApplicationInfo,
 {
     /// Close one or more [Windows](Window).


### PR DESCRIPTION
I initially made [EditContext](https://docs.rs/modalkit/0.0.16/modalkit/editing/context/trait.EditContext.html) a trait, so that the different keybindings for Vim, Emacs, etc., could implement it for their own context structs. I'd thought that this would make some things simpler in the Emacs keybindings since it could return constants for some of the methods, but it really just ends up complicating things for everyone who needs to consume `EditContext`, and makes some command bar features harder to implement.

I've converted `EditContext` into a struct, and turned `InputContext` into `InputState`, with an associate `Output` type. This ended up requiring updating a lot of places, but I think that the end result should be simpler.