### PR TITLE
Retry suffix of unmapped key sequences

### DIFF
--- a/src/editing/key.rs
+++ b/src/editing/key.rs
@@ -219,7 +219,7 @@ mod tests {
 
     impl Step<TerminalKey> for TestStep {
         type A = TestAction;
-        type C = VimState;
+        type State = VimState;
         type Class = CommonKeyClass;
         type M = TestMode;
         type Sequence = EmptySequence;

--- a/src/env/emacs/keybindings.rs
+++ b/src/env/emacs/keybindings.rs
@@ -255,7 +255,7 @@ impl<I: ApplicationInfo> Clone for InputStep<I> {
 
 impl<I: ApplicationInfo> Step<TerminalKey> for InputStep<I> {
     type A = Action<I>;
-    type C = EmacsState<I>;
+    type State = EmacsState<I>;
     type M = EmacsMode;
     type Class = CommonKeyClass;
     type Sequence = RepeatType;

--- a/src/env/mixed.rs
+++ b/src/env/mixed.rs
@@ -95,8 +95,8 @@ impl<K, I> BindingMachine<K, Action<I>, RepeatType, EditContext> for MixedBindin
 where
     K: InputKey,
     I: ApplicationInfo,
-    EmacsStep<I>: Step<K, A = Action<I>, Sequence = RepeatType, C = EmacsState<I>>,
-    VimStep<I>: Step<K, A = Action<I>, Sequence = RepeatType, C = VimState<I>>,
+    EmacsStep<I>: Step<K, A = Action<I>, Sequence = RepeatType, State = EmacsState<I>>,
+    VimStep<I>: Step<K, A = Action<I>, Sequence = RepeatType, State = VimState<I>>,
 {
     fn input_key(&mut self, key: K) {
         delegate_bindings!(self, BindingMachine::input_key, key)

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -9,7 +9,7 @@ use crossterm::event::KeyModifiers;
 use crate::{
     editing::base::Char,
     input::{
-        bindings::{EdgeEvent, EdgePath, EdgePathPart, InputKeyClass},
+        bindings::{EdgeEvent, EdgePathPart, InputKeyClass},
         key::{InputKey, TerminalKey},
     },
 };
@@ -25,7 +25,7 @@ pub mod vim;
 
 pub(crate) type CommonEdgeEvent = EdgeEvent<TerminalKey, CommonKeyClass>;
 pub(crate) type CommonEdgePathPart = EdgePathPart<TerminalKey, CommonKeyClass>;
-pub(crate) type CommonEdgePath = EdgePath<TerminalKey, CommonKeyClass>;
+pub(crate) type CommonEdgePath = Vec<CommonEdgePathPart>;
 
 /// Classes of characters that input keys can belong to.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -10,7 +10,7 @@ pub mod dialog;
 pub mod key;
 
 /// Represents contextual information that is updated upon user input.
-pub trait InputState: Clone + Default {
+pub trait InputState {
     /// The output context type returned along with actions.
     type Output: Clone + Default;
 


### PR DESCRIPTION
Currently, when an input sequence is unmapped, `ModeKeys::unmapped` gets called on just the last key in the sequence. This isn't the right behaviour, and makes it so that doing the common Insert mode mapping of "jj" or "jk" can't work right, since typing an unmapped sequence like "jo" will only type the "o" character. Instead, when a sequence is unmapped, `ModeKeys::unmapped` should be called on the _first_ character, and then the rest of the sequence should be retries. That way, if "jk" is mapped to "<Esc>", typing "jjk" will type "j" and then go to Normal mode.