### PR TITLE
Fix Clippy 1.75 warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ crossterm = "0.27"
 libc = "0.2"
 tui = { version = "0.23", optional = true, package = "ratatui" }
 intervaltree = { version = "0.2.6", optional = true }
-bitflags = "1.2"
+bitflags = "2.4.2"
 nom = "7.0.0"
 radix_trie = "0.2.1"
 regex = "^1.5"

--- a/src/editing/base.rs
+++ b/src/editing/base.rs
@@ -1177,6 +1177,7 @@ impl<T> From<T> for Specifier<T> {
 
 bitflags! {
     /// These flags are used to specify the behaviour while writing a window.
+    #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     pub struct WriteFlags: u32 {
         /// No flags set.
         const NONE = 0b00000000;
@@ -1188,6 +1189,7 @@ bitflags! {
 
 bitflags! {
     /// These flags are used to specify the behaviour while writing a window.
+    #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     pub struct OpenFlags: u32 {
         /// No flags set.
         const NONE = 0b00000000;
@@ -1202,6 +1204,7 @@ bitflags! {
 
 bitflags! {
     /// These flags are used to specify the behaviour while closing a window.
+    #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     pub struct CloseFlags: u32 {
         /// No flags set.
         const NONE = 0b00000000;
@@ -1216,10 +1219,10 @@ bitflags! {
         const QUIT  = 0b00000100;
 
         /// Write out the window's contents and quit.
-        const WQ = CloseFlags::WRITE.bits | CloseFlags::QUIT.bits;
+        const WQ = CloseFlags::WRITE.bits() | CloseFlags::QUIT.bits();
 
         /// Force quit the window.
-        const FQ = CloseFlags::FORCE.bits | CloseFlags::QUIT.bits;
+        const FQ = CloseFlags::FORCE.bits() | CloseFlags::QUIT.bits();
     }
 }
 
@@ -1472,6 +1475,7 @@ pub enum TargetShape {
 
 bitflags! {
     /// Bitmask that specifies what shapes are targeted by an action.
+    #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     pub struct TargetShapeFilter: u32 {
         /// Match no shapes.
         const NONE = 0b00000000;

--- a/src/editing/completion.rs
+++ b/src/editing/completion.rs
@@ -63,7 +63,7 @@ impl CompletionList {
                         self.selected = None;
                         return Some(self.prefix.clone());
                     },
-                    (Some(idx), MoveDir1D::Previous) if idx == 0 => {
+                    (Some(0), MoveDir1D::Previous) => {
                         self.selected = None;
                         return Some(self.prefix.clone());
                     },

--- a/src/editing/cursor/mod.rs
+++ b/src/editing/cursor/mod.rs
@@ -157,22 +157,6 @@ impl Cursor {
             },
         }
     }
-
-    fn compare(&self, other: &Cursor) -> Ordering {
-        let ycmp = self.y.cmp(&other.y);
-
-        if ycmp != Ordering::Equal {
-            return ycmp;
-        }
-
-        let xcmp = self.x.cmp(&other.x);
-
-        if xcmp != Ordering::Equal {
-            return xcmp;
-        }
-
-        self.xgoal.cmp(&other.xgoal)
-    }
 }
 
 /// Trait for adjusting cursors and objects that contain cursors.
@@ -243,13 +227,25 @@ impl Wrappable for Cursor {
 
 impl PartialOrd for Cursor {
     fn partial_cmp(&self, other: &Cursor) -> Option<Ordering> {
-        Some(self.compare(other))
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for Cursor {
     fn cmp(&self, other: &Cursor) -> Ordering {
-        self.compare(other)
+        let ycmp = self.y.cmp(&other.y);
+
+        if ycmp != Ordering::Equal {
+            return ycmp;
+        }
+
+        let xcmp = self.x.cmp(&other.x);
+
+        if xcmp != Ordering::Equal {
+            return xcmp;
+        }
+
+        self.xgoal.cmp(&other.xgoal)
     }
 }
 

--- a/src/editing/cursor/state.rs
+++ b/src/editing/cursor/state.rs
@@ -324,7 +324,7 @@ impl Default for CursorState {
 
 impl PartialOrd for CursorState {
     fn partial_cmp(&self, other: &CursorState) -> Option<Ordering> {
-        self.cmp(other).into()
+        Some(self.cmp(other))
     }
 }
 

--- a/src/editing/rope/mod.rs
+++ b/src/editing/rope/mod.rs
@@ -62,7 +62,7 @@ pub struct CharOff(usize);
 
 impl PartialOrd for CharOff {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.0.partial_cmp(&other.0)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/env/emacs/keybindings.rs
+++ b/src/env/emacs/keybindings.rs
@@ -75,13 +75,14 @@ use crate::input::{
 };
 
 bitflags! {
+    #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     struct MappedModes: u32 {
         const I = 0b0000000000000001;
         const C = 0b0000000000000010;
         const S = 0b0000000000000100;
 
-        const IC = MappedModes::I.bits | MappedModes::C.bits;
-        const ICS = MappedModes::IC.bits | MappedModes::S.bits;
+        const IC = MappedModes::I.bits() | MappedModes::C.bits();
+        const ICS = MappedModes::IC.bits() | MappedModes::S.bits();
     }
 }
 

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -133,13 +133,13 @@ fn is_mark_char(c: char) -> bool {
 
 /// Fields for tracking entered codepoints, literals and digraphs.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub(self) struct CharacterContext {
-    pub(self) dec: Option<u32>,
-    pub(self) oct: Option<u32>,
-    pub(self) hex: Option<u32>,
-    pub(self) any: Option<TerminalKey>,
-    pub(self) digraph1: Option<char>,
-    pub(self) digraph2: Option<char>,
+struct CharacterContext {
+    dec: Option<u32>,
+    oct: Option<u32>,
+    hex: Option<u32>,
+    any: Option<TerminalKey>,
+    digraph1: Option<char>,
+    digraph2: Option<char>,
 }
 
 impl CharacterContext {

--- a/src/env/vim/keybindings.rs
+++ b/src/env/vim/keybindings.rs
@@ -122,6 +122,7 @@ use crate::input::{
 };
 
 bitflags! {
+    #[derive(Debug, Clone, Copy)]
     struct MappedModes: u32 {
         const N = 0b0000000000000001;
         const X = 0b0000000000000010;
@@ -134,15 +135,15 @@ bitflags! {
         const SUFFIX_CHARSRCH = 0b1000000000000000;
         const SUFFIX_CHARREPL = 0b0100000000000000;
 
-        const V = MappedModes::X.bits | MappedModes::S.bits;
+        const V = MappedModes::X.bits() | MappedModes::S.bits();
 
-        const NVI = MappedModes::N.bits | MappedModes::V.bits | MappedModes::I.bits;
-        const NVO = MappedModes::N.bits | MappedModes::V.bits | MappedModes::O.bits;
-        const NXO = MappedModes::N.bits | MappedModes::X.bits | MappedModes::O.bits;
-        const NV = MappedModes::N.bits | MappedModes::V.bits;
-        const NX = MappedModes::N.bits | MappedModes::X.bits;
-        const VO = MappedModes::V.bits | MappedModes::O.bits;
-        const IC = MappedModes::I.bits | MappedModes::C.bits;
+        const NVI = MappedModes::N.bits() | MappedModes::V.bits() | MappedModes::I.bits();
+        const NVO = MappedModes::N.bits() | MappedModes::V.bits() | MappedModes::O.bits();
+        const NXO = MappedModes::N.bits() | MappedModes::X.bits() | MappedModes::O.bits();
+        const NV = MappedModes::N.bits() | MappedModes::V.bits();
+        const NX = MappedModes::N.bits() | MappedModes::X.bits();
+        const VO = MappedModes::V.bits() | MappedModes::O.bits();
+        const IC = MappedModes::I.bits() | MappedModes::C.bits();
     }
 }
 

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -146,7 +146,7 @@ impl Ord for ListCursor {
 
 impl PartialOrd for ListCursor {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.cmp(other).into()
+        Some(self.cmp(other))
     }
 }
 

--- a/src/widgets/windows/mod.rs
+++ b/src/widgets/windows/mod.rs
@@ -43,15 +43,15 @@ mod tree;
 
 pub use self::layout::{WindowLayout, WindowLayoutDescription, WindowLayoutState};
 
-pub(self) struct AxisTreeNode<W, X: AxisT, Y: AxisT> {
-    pub(self) value: Value<W, X, Y>,
-    pub(self) info: Info,
-    pub(self) left: Option<Box<Self>>,
-    pub(self) right: Option<Box<Self>>,
+struct AxisTreeNode<W, X: AxisT, Y: AxisT> {
+    value: Value<W, X, Y>,
+    info: Info,
+    left: Option<Box<Self>>,
+    right: Option<Box<Self>>,
     _p: PhantomData<(X, Y)>,
 }
 
-pub(self) type AxisTree<W, X, Y> = Option<Box<AxisTreeNode<W, X, Y>>>;
+type AxisTree<W, X, Y> = Option<Box<AxisTreeNode<W, X, Y>>>;
 
 struct Info {
     dimensions: (usize, usize),
@@ -114,7 +114,7 @@ impl WindowInfo {
     }
 }
 
-pub(self) enum Value<W, X: AxisT, Y: AxisT> {
+enum Value<W, X: AxisT, Y: AxisT> {
     Window(W, WindowInfo),
     Tree(Box<AxisTreeNode<W, Y, X>>, TreeInfo),
 }
@@ -192,12 +192,12 @@ where
     }
 }
 
-pub(self) trait AxisT: std::fmt::Debug {
+trait AxisT: std::fmt::Debug {
     fn axis() -> Axis;
 }
 
 #[derive(Debug)]
-pub(self) enum HorizontalT {}
+enum HorizontalT {}
 
 impl AxisT for HorizontalT {
     fn axis() -> Axis {
@@ -206,7 +206,7 @@ impl AxisT for HorizontalT {
 }
 
 #[derive(Debug)]
-pub(self) enum VerticalT {}
+enum VerticalT {}
 
 impl AxisT for VerticalT {
     fn axis() -> Axis {
@@ -214,7 +214,7 @@ impl AxisT for VerticalT {
     }
 }
 
-pub(self) fn winnr_cmp(at: usize, lsize: usize, vsize: usize) -> (Ordering, usize) {
+fn winnr_cmp(at: usize, lsize: usize, vsize: usize) -> (Ordering, usize) {
     if at < lsize {
         (Ordering::Less, at)
     } else if at - lsize < vsize {


### PR DESCRIPTION
The MSRV is still 1.67, but this should keep it easy to work with newer Rust toolchains locally.