### PR TITLE
Add Eq and PartialEq back to CommandContext

### DIFF
--- a/crates/modalkit/src/env/vim/command/mod.rs
+++ b/crates/modalkit/src/env/vim/command/mod.rs
@@ -91,7 +91,7 @@ where
 }
 
 /// Context object passed to each [CommandFunc].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CommandContext {
     /// Contextual information from user input.
     pub context: EditContext,


### PR DESCRIPTION
I had removed these in #125, because I was thinking that I didn't want to allow comparisons against the context, but this actually makes it hard to embed it into other things that need to derive `Eq`/`PartialEq` in `iamb`, so I'm adding it back. 