### PR TITLE
Use exactly arboard@3.3.0 for now

### DIFF
--- a/crates/modalkit/Cargo.toml
+++ b/crates/modalkit/Cargo.toml
@@ -16,7 +16,7 @@ rust-version.workspace = true
 
 [dependencies]
 anymap2 = "0.13.0"
-arboard = "3.2.0"
+arboard = "=3.3.0"
 bitflags = { workspace = true }
 crossterm = { workspace = true }
 derive_more = "0.99.16"


### PR DESCRIPTION
CI broke on #131 because a change in `arboard@3.3.1` doesn't compile on Windows. Hopefully it's the only issue, and going back to `arboard@3.3.0` works.