### PR TITLE
Add MacroAction::Run variant to make custom keybindings easier

### DIFF
--- a/crates/modalkit/src/editing/action.rs
+++ b/crates/modalkit/src/editing/action.rs
@@ -428,9 +428,14 @@ where
 #[non_exhaustive]
 pub enum MacroAction {
     /// Execute the contents of the contextually specified Register [*n* times](Count).
+    ///
+    /// If no register is specified, then this should default to [Register::UnnamedMacro].
     Execute(Count),
 
-    /// Execute the contents of the previously specified macro [*n* times](Count).
+    /// Run the given macro string [*n* times](Count).
+    Run(String, Count),
+
+    /// Execute the contents of the previously specified register [*n* times](Count).
     Repeat(Count),
 
     /// Start or stop recording a macro.


### PR DESCRIPTION
This adds a `MacroAction` variant that fetches the macro from the `String` argument instead of looking up the macro from the specified register. This should make it easier to implement simple keybindings that map to a series of kepresses in iamb for now.