### PR TITLE
Limit recursive macros

### DIFF
--- a/crates/modalkit/src/key/mod.rs
+++ b/crates/modalkit/src/key/mod.rs
@@ -24,6 +24,10 @@ pub enum MacroError {
     /// Empty macro string.
     #[error("Empty macro string")]
     EmptyMacro,
+
+    /// A macro that seems to be looping.
+    #[error("Ending suspected macro loop; macro run {0} times w/o keyboard input")]
+    LoopingMacro(usize),
 }
 
 /// A key pressed in a terminal.


### PR DESCRIPTION
While looking at using `MacroAction::Run` to implement custom keybindings in iamb, I realized that there should be something that prevents getting caught executing a macro without human input forever. For now, I've just made this 100, but I can make it adjustable in the future if it ever comes up.