### PR TITLE
Save zoom and focused window from layout so that it can be restored

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -614,6 +614,7 @@ dependencies = [
  "ratatui",
  "regex",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -981,6 +982,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/crates/modalkit-ratatui/Cargo.toml
+++ b/crates/modalkit-ratatui/Cargo.toml
@@ -22,3 +22,4 @@ serde = { version = "^1.0", features = ["derive"] }
 
 [dev-dependencies]
 rand = { workspace = true }
+serde_json = "1.0.122"

--- a/crates/modalkit-ratatui/src/screen.rs
+++ b/crates/modalkit-ratatui/src/screen.rs
@@ -22,7 +22,7 @@ use ratatui::{
 use super::{
     cmdbar::{CommandBar, CommandBarState},
     util::{rect_down, rect_zero_height},
-    windows::{WindowActions, WindowLayout, WindowLayoutState, WindowLayoutStorage},
+    windows::{WindowActions, WindowLayout, WindowLayoutRoot, WindowLayoutState},
     TerminalCursor,
     Window,
     WindowOps,
@@ -246,7 +246,7 @@ fn bold<'a>(s: String) -> Span<'a> {
 #[serde(bound(serialize = "I::WindowId: Serialize"))]
 pub struct TabbedLayoutDescription<I: ApplicationInfo> {
     /// The description of the window layout for each tab.
-    pub tabs: Vec<WindowLayoutStorage<I>>,
+    pub tabs: Vec<WindowLayoutRoot<I>>,
     /// The index of the last focused tab
     pub focused: usize,
 }

--- a/crates/modalkit-ratatui/src/windows/layout.rs
+++ b/crates/modalkit-ratatui/src/windows/layout.rs
@@ -1106,14 +1106,14 @@ where
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(bound(deserialize = "I::WindowId: Deserialize<'de>"))]
 #[serde(bound(serialize = "I::WindowId: Serialize"))]
-#[serde(rename_all = "lowercase", tag = "type")]
-pub struct WindowLayoutStorage<I: ApplicationInfo> {
+#[serde(rename_all = "lowercase")]
+pub struct WindowLayoutRoot<I: ApplicationInfo> {
     layout: WindowLayoutDescription<I>,
     focused: usize,
     zoomed: bool,
 }
 
-impl<I> WindowLayoutStorage<I>
+impl<I> WindowLayoutRoot<I>
 where
     I: ApplicationInfo,
 {
@@ -1310,13 +1310,13 @@ where
     }
 
     /// Convert this layout to a serializable summary of its windows and splits.
-    pub fn as_description(&self) -> WindowLayoutStorage<I> {
+    pub fn as_description(&self) -> WindowLayoutRoot<I> {
         let mut children = vec![];
         let focused = self.focused;
         let zoomed = self.zoom;
 
         let Some(root) = &self.root else {
-            return WindowLayoutStorage {
+            return WindowLayoutRoot {
                 layout: WindowLayoutDescription::Split { children, length: None },
                 focused,
                 zoomed,
@@ -1327,7 +1327,7 @@ where
             children.push(w.into());
         }
 
-        return WindowLayoutStorage {
+        return WindowLayoutRoot {
             layout: WindowLayoutDescription::Split { children, length: None },
             focused,
             zoomed,
@@ -2904,5 +2904,10 @@ mod tests {
             .to_layout::<TestWindow>(tree.info.area.into(), &mut store)
             .unwrap();
         assert_eq!(tree.as_description(), desc1);
+
+        // Test against an example JSON serialization to test naming.
+        let serialized = serde_json::to_string_pretty(&desc1).unwrap();
+        let exp = include_str!("../../tests/window-layout.json");
+        assert_eq!(serialized, exp.trim_end());
     }
 }

--- a/crates/modalkit-ratatui/src/windows/layout.rs
+++ b/crates/modalkit-ratatui/src/windows/layout.rs
@@ -1124,11 +1124,12 @@ where
         store: &mut Store<I>,
     ) -> UIResult<WindowLayoutState<W, I>, I> {
         let mut layout = self.layout.to_layout(area, store)?;
-        layout.focused = self.focused;
+        layout._focus(self.focused);
         layout.zoom = self.zoomed;
         Ok(layout)
     }
 }
+
 /// A description of a window layout.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(bound(deserialize = "I::WindowId: Deserialize<'de>"))]
@@ -2845,6 +2846,7 @@ mod tests {
         let (mut tree, mut store, _) = three_by_three();
         let mut buffer = Buffer::empty(Rect::new(0, 0, 60, 60));
         let area = Rect::new(0, 0, 60, 60);
+        tree._focus(3);
 
         // Draw so that everything gets an initial area.
         WindowLayout::new(&mut store).render(area, &mut buffer, &mut tree);
@@ -2893,6 +2895,8 @@ mod tests {
             length: None,
         };
         assert_eq!(desc1.layout, exp);
+        assert_eq!(desc1.focused, 3);
+        assert_eq!(desc1.zoomed, false);
 
         // Turn back into a layout, and then generate a new description to show it's the same.
         let tree = desc1

--- a/crates/modalkit-ratatui/src/windows/mod.rs
+++ b/crates/modalkit-ratatui/src/windows/mod.rs
@@ -30,7 +30,12 @@ mod size;
 mod slot;
 mod tree;
 
-pub use self::layout::{WindowLayout, WindowLayoutDescription, WindowLayoutState};
+pub use self::layout::{
+    WindowLayout,
+    WindowLayoutDescription,
+    WindowLayoutState,
+    WindowLayoutStorage,
+};
 
 struct AxisTreeNode<W, X: AxisT, Y: AxisT> {
     value: Value<W, X, Y>,

--- a/crates/modalkit-ratatui/src/windows/mod.rs
+++ b/crates/modalkit-ratatui/src/windows/mod.rs
@@ -33,8 +33,8 @@ mod tree;
 pub use self::layout::{
     WindowLayout,
     WindowLayoutDescription,
+    WindowLayoutRoot,
     WindowLayoutState,
-    WindowLayoutStorage,
 };
 
 struct AxisTreeNode<W, X: AxisT, Y: AxisT> {

--- a/crates/modalkit-ratatui/tests/window-layout.json
+++ b/crates/modalkit-ratatui/tests/window-layout.json
@@ -1,0 +1,91 @@
+{
+  "layout": {
+    "type": "split",
+    "children": [
+      {
+        "type": "split",
+        "children": [
+          {
+            "type": "split",
+            "children": [
+              {
+                "type": "split",
+                "children": [
+                  {
+                    "type": "window",
+                    "window": 0,
+                    "length": 20
+                  },
+                  {
+                    "type": "window",
+                    "window": 1,
+                    "length": 20
+                  }
+                ],
+                "length": 20
+              },
+              {
+                "type": "split",
+                "children": [
+                  {
+                    "type": "window",
+                    "window": 2,
+                    "length": 20
+                  },
+                  {
+                    "type": "window",
+                    "window": 3,
+                    "length": 20
+                  }
+                ],
+                "length": 20
+              },
+              {
+                "type": "split",
+                "children": [
+                  {
+                    "type": "window",
+                    "window": 4,
+                    "length": 20
+                  },
+                  {
+                    "type": "window",
+                    "window": 5,
+                    "length": 20
+                  }
+                ],
+                "length": 20
+              }
+            ],
+            "length": 40
+          },
+          {
+            "type": "split",
+            "children": [
+              {
+                "type": "window",
+                "window": 6,
+                "length": 20
+              },
+              {
+                "type": "window",
+                "window": 7,
+                "length": 20
+              },
+              {
+                "type": "window",
+                "window": 8,
+                "length": 20
+              }
+            ],
+            "length": 20
+          }
+        ],
+        "length": 60
+      }
+    ],
+    "length": null
+  },
+  "focused": 3,
+  "zoomed": false
+}


### PR DESCRIPTION
Hi,

This PR is to support restoring layouts with with zoom and focus.
Related issues:
- https://github.com/ulyssa/iamb/issues/247
- https://github.com/ulyssa/iamb/issues/250

A new struct `WindowLayoutStorage` has been created to store: the windows layout, which window is in focus, and if the focused window is zoomed. 

`TabLayoutDescription` has been updated to hold this struct in place of `WindowLayoutStorage` as well as store the currently selected tab.

I am not set on the name `WindowLayoutStorage`; would you be open to naming it `TabLayoutDescription`, and rename `TablayoutDescription` to `AppLayoutDescription` or something similar?

This seems more logical to me as currently `TabLayoutDescription` does not hold the layout of a tab, but rather the layout of the top level application.

Keen to hear your thoughts. :)