### PR TITLE
Keybindings should provide Action to command bar

### DIFF
--- a/crates/modalkit-ratatui/examples/editor.rs
+++ b/crates/modalkit-ratatui/examples/editor.rs
@@ -681,7 +681,9 @@ impl Editor {
                 None
             },
             Action::Command(act) => {
-                let acts = self.store.application.cmds.command(&act, &ctx)?;
+                let astore = &mut self.store.application;
+                let rstore = &mut self.store.registers;
+                let acts = astore.cmds.command(&act, &ctx, rstore)?;
                 self.action_prepend(acts);
 
                 None

--- a/crates/modalkit-ratatui/src/list.rs
+++ b/crates/modalkit-ratatui/src/list.rs
@@ -624,8 +624,8 @@ where
                         let dir = ctx.get_search_regex_dir();
                         let dir = flip.resolve(&dir);
 
-                        let lsearch = store.registers.get(&Register::LastSearch)?;
-                        let lsearch = lsearch.value.to_string();
+                        let lsearch = store.registers.get_last_search();
+                        let lsearch = lsearch.to_string();
                         let needle = Regex::new(lsearch.as_ref())?;
 
                         self.find_regex(&self.cursor, dir, &needle, count).map(|r| r.start)
@@ -690,8 +690,8 @@ where
                         let dir = ctx.get_search_regex_dir();
                         let dir = flip.resolve(&dir);
 
-                        let lsearch = store.registers.get(&Register::LastSearch)?;
-                        let lsearch = lsearch.value.to_string();
+                        let lsearch = store.registers.get_last_search();
+                        let lsearch = lsearch.to_string();
                         let needle = Regex::new(lsearch.as_ref())?;
 
                         self.find_regex(&self.cursor, dir, &needle, count)
@@ -1610,7 +1610,7 @@ mod tests {
     fn test_search() {
         let (mut list, ctx, mut store) = mklist();
 
-        store.set_last_search("on");
+        store.registers.set_last_search("on");
 
         assert_eq!(list.cursor.position, 0);
 

--- a/crates/modalkit-ratatui/src/screen.rs
+++ b/crates/modalkit-ratatui/src/screen.rs
@@ -345,10 +345,16 @@ where
         self.last_message = false;
     }
 
-    fn focus_command(&mut self, ct: CommandType, dir: MoveDir1D) -> EditResult<EditInfo, I> {
+    fn focus_command(
+        &mut self,
+        prompt: &str,
+        ct: CommandType,
+        act: &Action<I>,
+        ctx: &EditContext,
+    ) -> EditResult<EditInfo, I> {
         self.focused = CurrentFocus::Command;
         self.cmdbar.reset();
-        self.cmdbar.set_type(ct, dir);
+        self.cmdbar.set_type(prompt, ct, act, ctx);
         self.clear_message();
 
         Ok(None)
@@ -364,11 +370,11 @@ where
     /// Perform a command bar action.
     pub fn command_bar(
         &mut self,
-        act: &CommandBarAction,
+        act: &CommandBarAction<I>,
         ctx: &EditContext,
     ) -> EditResult<EditInfo, I> {
         match act {
-            CommandBarAction::Focus(ct) => self.focus_command(*ct, ctx.get_search_regex_dir()),
+            CommandBarAction::Focus(s, ct, act) => self.focus_command(s, *ct, act, ctx),
             CommandBarAction::Unfocus => self.focus_window(),
         }
     }

--- a/crates/modalkit/src/editing/application.rs
+++ b/crates/modalkit/src/editing/application.rs
@@ -161,7 +161,7 @@ use crate::{
 /// create additional keybindings and commands on top of the defaults provided within
 /// [modalkit::env](crate::env).
 ///
-/// [Action::Application]: super::actions::Action::Application
+/// [Action::Application]: crate::actions::Action::Application
 pub trait ApplicationAction: Clone + Debug + Eq + PartialEq + Send {
     /// Allows controlling how application-specific actions are included in
     /// [RepeatType::EditSequence](crate::prelude::RepeatType::EditSequence).
@@ -177,7 +177,7 @@ pub trait ApplicationAction: Clone + Debug + Eq + PartialEq + Send {
 
     /// Allows controlling whether an application-specific action can cause
     /// a buffer switch on an
-    /// [EditError::WrongBuffer](crate::actions::EditError::WrongBuffer).
+    /// [EditError::WrongBuffer](crate::errors::EditError::WrongBuffer).
     fn is_switchable(&self, ctx: &EditContext) -> bool;
 }
 

--- a/crates/modalkit/src/editing/buffer/mod.rs
+++ b/crates/modalkit/src/editing/buffer/mod.rs
@@ -367,7 +367,7 @@ where
             Regex::new(word.as_str())
         }?;
 
-        store.set_last_search(needle.to_string());
+        store.registers.set_last_command(CommandType::Search, needle.to_string());
 
         let res = self.text.find_regex(&cursor, dir, &needle, count);
 
@@ -397,7 +397,7 @@ where
     }
 
     fn _get_regex(&self, store: &Store<I>) -> EditResult<Regex, I> {
-        let lsearch = store.registers.get(&Register::LastSearch)?.value;
+        let lsearch = store.registers.get_last_search();
         let regex = Regex::new(lsearch.to_string().as_ref())?;
 
         return Ok(regex);
@@ -2034,7 +2034,7 @@ mod tests {
         let op = EditAction::Motion;
         let mv = EditTarget::Search(SearchType::Regex, MoveDirMod::Same, Count::Contextual);
 
-        store.set_last_search("he");
+        store.registers.set_last_search("he");
 
         // Move to (0, 6) to begin.
         ebuf.set_leader(gid, Cursor::new(0, 6));

--- a/crates/modalkit/src/editing/buffer/selection.rs
+++ b/crates/modalkit/src/editing/buffer/selection.rs
@@ -1778,7 +1778,7 @@ mod tests {
         assert_eq!(ebuf.get_follower_selections(curid), Some(fsels.clone()));
 
         // Set regex to /he/.
-        store.set_last_search("he");
+        store.registers.set_last_search("he");
 
         // Keep selections matching /he/.
         ebuf.selection_filter(false, ctx!(curid, vwctx, vctx), &mut store).unwrap();
@@ -1830,7 +1830,7 @@ mod tests {
         assert_eq!(ebuf.get_follower_selections(curid), Some(fsels.clone()));
 
         // Set regex to /he/.
-        store.set_last_search("he");
+        store.registers.set_last_search("he");
 
         // Drop selections matching /he/.
         ebuf.selection_filter(true, ctx!(curid, vwctx, vctx), &mut store).unwrap();

--- a/crates/modalkit/src/editing/rope/mod.rs
+++ b/crates/modalkit/src/editing/rope/mod.rs
@@ -2241,6 +2241,12 @@ impl EditRope {
     }
 }
 
+impl Default for EditRope {
+    fn default() -> Self {
+        EditRope::empty()
+    }
+}
+
 impl Add for EditRope {
     type Output = Self;
 

--- a/crates/modalkit/src/env/vim/mod.rs
+++ b/crates/modalkit/src/env/vim/mod.rs
@@ -558,9 +558,9 @@ fn register_to_char((reg, append): &(Register, bool)) -> Option<String> {
         Register::UnnamedMacro => '@',
         Register::UnnamedCursorGroup => return None,
         Register::SmallDelete => '-',
-        Register::LastCommand => ':',
+        Register::LastCommand(CommandType::Command) => ':',
+        Register::LastCommand(CommandType::Search) => '/',
         Register::LastInserted => '.',
-        Register::LastSearch => '/',
         Register::LastYanked => '0',
         Register::AltBufName => '#',
         Register::CurBufName => '%',
@@ -598,9 +598,9 @@ fn char_to_register(c: char) -> Option<(Register, bool)> {
         '#' => Register::AltBufName,
         '_' => Register::Blackhole,
         '%' => Register::CurBufName,
-        ':' => Register::LastCommand,
+        ':' => Register::LastCommand(CommandType::Command),
+        '/' => Register::LastCommand(CommandType::Search),
         '.' => Register::LastInserted,
-        '/' => Register::LastSearch,
         '*' => Register::SelectionPrimary,
         '+' => Register::SelectionClipboard,
 
@@ -698,7 +698,10 @@ mod tests {
         assert_eq!(char_to_register('1'), Some((Register::RecentlyDeleted(0), false)));
         assert_eq!(char_to_register('3'), Some((Register::RecentlyDeleted(2), false)));
         assert_eq!(char_to_register('"'), Some((Register::Unnamed, false)));
-        assert_eq!(char_to_register('/'), Some((Register::LastSearch, false)));
+        assert_eq!(
+            char_to_register('/'),
+            Some((Register::LastCommand(CommandType::Search), false))
+        );
 
         // Unmapped names.
         assert_eq!(char_to_register('['), None);
@@ -712,7 +715,10 @@ mod tests {
         assert_eq!(register_to_char(&(Register::RecentlyDeleted(0), false)).unwrap(), "1");
         assert_eq!(register_to_char(&(Register::RecentlyDeleted(2), false)).unwrap(), "3");
         assert_eq!(register_to_char(&(Register::Unnamed, false)).unwrap(), "\"");
-        assert_eq!(register_to_char(&(Register::LastSearch, false)).unwrap(), "/");
+        assert_eq!(
+            register_to_char(&(Register::LastCommand(CommandType::Search), false)).unwrap(),
+            "/"
+        );
 
         // Registers that don't have names.
         assert_eq!(register_to_char(&(Register::UnnamedCursorGroup, false)), None);

--- a/crates/modalkit/src/prelude.rs
+++ b/crates/modalkit/src/prelude.rs
@@ -4,7 +4,7 @@
 //!
 //! These types are used to specify the details of [actions].
 //!
-//! [actions]: crate::action
+//! [actions]: crate::actions
 use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::Hash;
 
@@ -265,12 +265,12 @@ pub enum SearchType {
     /// Search for a regular expression.
     Regex,
 
-    /// Search for the word currently under the cursor, and update [Register::LastSearch] via
-    /// [Store::set_last_search].
+    /// Search for the word currently under the cursor, and update the last [CommandType::Search].
+    /// via [RegisterStore::set_last_search].
     ///
     /// [bool] controls whether matches should be checked for using word boundaries.
     ///
-    /// [Store::set_last_search]: crate::editing::store::Store::set_last_search
+    /// [RegisterStore::set_last_search]: crate::editing::store::RegisterStore::set_last_search
     Word(WordStyle, bool),
 }
 
@@ -1373,20 +1373,15 @@ pub enum Register {
     /// For example, `"-` in Vim.
     SmallDelete,
 
-    /// A register containing the last executed command.
-    ///
-    /// For example, `":` in Vim.
-    LastCommand,
-
     /// A register containing the last inserted text.
     ///
     /// For example, `".` in Vim.
     LastInserted,
 
-    /// A register containing the last search expression.
+    /// A register containing the last value entered for a [CommandType].
     ///
-    /// For example, `"/` in Vim.
-    LastSearch,
+    /// For example, `":` and `"/` in Vim.
+    LastCommand(CommandType),
 
     /// A register containing the last copied text.
     ///
@@ -1440,9 +1435,8 @@ impl Register {
             Register::UnnamedMacro => false,
             Register::RecentlyDeleted(_) => false,
             Register::SmallDelete => false,
-            Register::LastCommand => false,
+            Register::LastCommand(_) => false,
             Register::LastInserted => false,
-            Register::LastSearch => false,
             Register::LastYanked => false,
             Register::AltBufName => false,
             Register::CurBufName => false,
@@ -1521,7 +1515,7 @@ pub enum RangeEndingType {
     /// The position of a given [Mark].
     Mark(Specifier<Mark>),
 
-    /// The line matching a search using the value of [Register::LastSearch].
+    /// The line matching a search using the last value of [CommandType::Search].
     Search(MoveDir1D),
 
     /// Perform a search using the last substitution pattern.

--- a/crates/scansion/src/editor.rs
+++ b/crates/scansion/src/editor.rs
@@ -137,7 +137,7 @@ where
 
     fn _redraw_wrap(
         &mut self,
-        prompt: &Option<String>,
+        prompt: Option<&str>,
         off: u16,
         context: &mut EditorContext,
     ) -> Result<u16, io::Error> {
@@ -265,7 +265,7 @@ where
 
     fn _redraw_nowrap(
         &mut self,
-        _: &Option<String>,
+        _: Option<&str>,
         _: u16,
         _: &mut EditorContext,
     ) -> Result<u16, io::Error> {
@@ -278,7 +278,7 @@ where
 
     pub fn redraw(
         &mut self,
-        prompt: &Option<String>,
+        prompt: Option<&str>,
         off: u16,
         context: &mut EditorContext,
     ) -> Result<u16, io::Error> {


### PR DESCRIPTION
In addition to jumping through a buffer to matching regular expressions, Kakoune can perform other actions that all use the same search regex history and interact with the same register (see #62 and #63 for example).

In order to support these, focusing the command bar should specify the action to take when submitting its contents. I've replaced `Register::LastSearch` (`"/`) and `Register::LastCommand` (`":`) with a `Register::LastCommand(CommandType)` variant. History for their contents has also moved into the `RegisterStore`, and is done in a way that should make #69, #130, and any other new command bar types very straightforward to implement.