### PR TITLE
Change default for `last_column` in `EditContext`

### DIFF
--- a/crates/modalkit-ratatui/src/textbox.rs
+++ b/crates/modalkit-ratatui/src/textbox.rs
@@ -1176,6 +1176,7 @@ where
 mod tests {
     use super::*;
     use modalkit::editing::store::Store;
+    use modalkit::env::vim::VimState;
 
     macro_rules! mv {
         ($mt: expr) => {
@@ -1217,7 +1218,7 @@ mod tests {
 
     fn mkboxstr(s: &str) -> (TextBoxState, EditContext, Store<EmptyInfo>) {
         let (mut b, mut store) = mkbox();
-        let ctx = EditContext::default();
+        let ctx = EditContext::from(VimState::<EmptyInfo>::default());
 
         b.set_text(s);
         b.editor_command(&HistoryAction::Checkpoint.into(), &ctx, &mut store)

--- a/crates/modalkit/src/editing/buffer/mod.rs
+++ b/crates/modalkit/src/editing/buffer/mod.rs
@@ -1410,6 +1410,7 @@ where
 mod tests {
     pub use super::*;
     pub use crate::editing::application::EmptyInfo;
+    pub use crate::editing::context::EditContextBuilder;
     pub use crate::editing::store::{RegisterCell, RegisterPutFlags, Store};
     pub use crate::prelude::TargetShape::{BlockWise, CharWise, LineWise};
 
@@ -1426,7 +1427,7 @@ mod tests {
     }
 
     pub(super) fn mkctx() -> EditContext {
-        EditContext::default()
+        EditContextBuilder::default().last_column(false).build()
     }
 
     pub(super) fn mkbuf() -> EditBuffer<EmptyInfo> {

--- a/crates/modalkit/src/editing/context.rs
+++ b/crates/modalkit/src/editing/context.rs
@@ -43,7 +43,7 @@ impl Default for EditContext {
             cursor_end: CursorEnd::Auto,
             target_shape: None,
             insert_style: None,
-            last_column: false,
+            last_column: true,
             register: None,
             register_append: false,
             search_regex_dir: MoveDir1D::Next,
@@ -155,30 +155,40 @@ impl EditContextBuilder {
     }
 
     /// Set the [CursorEnd].
+    ///
+    /// Defaults to [CursorEnd::Auto].
     pub fn cursor_end(mut self, v: CursorEnd) -> Self {
         self.0.cursor_end = v;
         self
     }
 
     /// Set the [TargetShape].
+    ///
+    /// Defaults to [None].
     pub fn target_shape(mut self, v: Option<TargetShape>) -> Self {
         self.0.target_shape = v;
         self
     }
 
     /// Set the [InsertStyle].
+    ///
+    /// Defaults to [None].
     pub fn insert_style(mut self, v: Option<InsertStyle>) -> Self {
         self.0.insert_style = v;
         self
     }
 
     /// Set whether it's okay to move the cursor into the last column.
+    ///
+    /// Defaults to [true].
     pub fn last_column(mut self, v: bool) -> Self {
         self.0.last_column = v;
         self
     }
 
     /// Set the [Register].
+    ///
+    /// Defaults to [None].
     pub fn register(mut self, v: Option<Register>) -> Self {
         self.0.register = v;
         self
@@ -186,54 +196,72 @@ impl EditContextBuilder {
 
     /// Set whether this operation should append contents to the register or replace the existing
     /// ones.
+    ///
+    /// Defaults to [false].
     pub fn register_append(mut self, v: bool) -> Self {
         self.0.register_append = v;
         self
     }
 
     /// Set the direction the regular expression should search in.
+    ///
+    /// Defaults to [MoveDir1D::Next].
     pub fn search_regex_dir(mut self, v: MoveDir1D) -> Self {
         self.0.search_regex_dir = v;
         self
     }
 
     /// Set a character to search for.
+    ///
+    /// Defaults to [None].
     pub fn search_char(mut self, v: Option<(MoveDir1D, bool, Char)>) -> Self {
         self.0.search_char = v;
         self
     }
 
     /// Set a [Char] to replace existing characters with.
+    ///
+    /// Defaults to [None].
     pub fn replace_char(mut self, v: Option<Char>) -> Self {
         self.0.replace_char = v;
         self
     }
 
     /// Set whether we should do an incremental search.
+    ///
+    /// Defaults to [false].
     pub fn search_incremental(mut self, v: bool) -> Self {
         self.0.search_incremental = v;
         self
     }
 
     /// Set the contextual [Mark].
+    ///
+    /// Defaults to [None].
     pub fn mark(mut self, mark: Option<Mark>) -> Self {
         self.0.mark = mark;
         self
     }
 
     /// Set the contextual [Mark].
+    ///
+    /// Defaults to [None].
     pub fn typed_char(mut self, ch: Option<Char>) -> Self {
         self.0.typed = ch;
         self
     }
 
     /// Set the contextual [Mark].
+    ///
+    /// Defaults to [EditAction::Motion].
     pub fn operation(mut self, op: EditAction) -> Self {
         self.0.operation = op;
         self
     }
 
     /// Set the contextual count.
+    ///
+    /// Defaults to [None].
     pub fn count(mut self, n: Option<usize>) -> Self {
         self.0.count = n;
         self

--- a/crates/modalkit/src/editing/key.rs
+++ b/crates/modalkit/src/editing/key.rs
@@ -457,7 +457,7 @@ mod tests {
     #[test]
     fn test_macro_run() {
         let (mut bindings, mut store) = setup_bindings(true);
-        let ctx = EditContext::default();
+        let ctx = EditContext::from(VimState::<EmptyInfo>::default());
 
         // Run a sequence of key presses twice.
         let run = MacroAction::Run("flif<Esc>fi".into(), 2.into());

--- a/crates/modalkit/src/editing/rope/mod.rs
+++ b/crates/modalkit/src/editing/rope/mod.rs
@@ -2758,6 +2758,13 @@ mod tests {
         };
     }
 
+    fn mkctx_vim() -> EditContext {
+        use crate::editing::application::EmptyInfo;
+        use crate::env::vim::VimState;
+
+        VimState::<EmptyInfo>::default().into()
+    }
+
     #[test]
     fn test_max_line_idx() {
         let r = EditRope::from("a\nbc\n\ndefg\nhijkl\n");
@@ -3996,7 +4003,7 @@ mod tests {
     fn test_motion_char_line() {
         let rope = EditRope::from("hello\nworld\na b c d e\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let mut vctx = EditContext::default();
+        let mut vctx = mkctx_vim();
         let mut cursor = rope.first();
         let count = Count::Contextual;
 
@@ -4089,7 +4096,7 @@ mod tests {
     fn test_motion_column_wrap() {
         let rope = EditRope::from("hello\nworld\na b c d e\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let mut vctx = EditContext::default();
+        let mut vctx = mkctx_vim();
         let mut cursor = rope.first();
         let count = Count::Contextual;
 
@@ -4134,7 +4141,7 @@ mod tests {
     fn test_motion_word_accents() {
         let rope = EditRope::from("árvíztűrő tükörfúrógép");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let mut cursor = rope.first();
         let count = Count::Contextual;
 
@@ -4155,7 +4162,7 @@ mod tests {
     fn test_motion_word() {
         let rope = EditRope::from("hello world\na,b,c,d e,f,g,h\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let mut cursor = rope.first();
         let count = Count::Contextual;
 
@@ -4333,7 +4340,7 @@ mod tests {
     fn test_motion_word_begin_nonalphanum() {
         let rope = EditRope::from("hello   world  \nhow,are ,, you,doing\n today\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let mut vctx = EditContext::default();
+        let mut vctx = mkctx_vim();
         let mut cursor = rope.first();
         let count = Count::Contextual;
 
@@ -4429,7 +4436,7 @@ mod tests {
     fn test_motion_word_alphanum() {
         let rope = EditRope::from("hello   world  \nhow,are ,, you,doing\n today\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let mut vctx = EditContext::default();
+        let mut vctx = mkctx_vim();
         let mut cursor = rope.first();
         let count = Count::Contextual;
 
@@ -4528,7 +4535,7 @@ mod tests {
     fn test_final_non_blank() {
         let rope = EditRope::from("hello world       \na b c d e  \n12345\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let mut cursor = rope.first();
 
         assert_eq!(cursor, Cursor::new(0, 0));
@@ -4574,7 +4581,7 @@ mod tests {
     fn test_first_word() {
         let rope = EditRope::from("       hello world\n  a b c d e\n    first\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let mut cursor = rope.first();
 
         assert_eq!(cursor, Cursor::new(0, 0));
@@ -4607,7 +4614,7 @@ mod tests {
     fn test_motion_line_pos() {
         let rope = EditRope::from("1234567890\nabcde\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let mut vctx = EditContext::default();
+        let mut vctx = mkctx_vim();
         let mut cursor = rope.first();
 
         assert_eq!(cursor, Cursor::new(0, 0));
@@ -4653,7 +4660,7 @@ mod tests {
             klmnopqrst\n",
         );
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let mut cursor = rope.first();
 
         let mov = MoveType::LineColumnOffset;
@@ -4688,7 +4695,7 @@ mod tests {
     fn test_motion_line_percent() {
         let rope = EditRope::from("abcdefghijklmnopqrstuvwxyz\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let mut cursor = rope.first();
 
         let mov = MoveType::LinePercent;
@@ -4723,7 +4730,7 @@ mod tests {
             klmnopqrst\n",
         );
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let mut cursor = rope.first();
 
         let mov = MoveType::BufferByteOffset;
@@ -4771,7 +4778,7 @@ mod tests {
             1234567890\n",
         );
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let mut cursor = rope.first();
 
         // Move to end of buffer ("8G")
@@ -4812,7 +4819,7 @@ mod tests {
             abcdefghij\n",
         );
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let mut cursor = rope.first();
 
         // Move to end of buffer ("100%")
@@ -4856,7 +4863,7 @@ mod tests {
             1234567890\n",
         );
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let mut cursor = rope.first();
         let count = Count::Contextual;
 
@@ -4892,7 +4899,7 @@ mod tests {
             KLMNO\n",
         );
         let mut vwctx = ViewportContext::<Cursor>::default();
-        let mut vctx = EditContext::default();
+        let mut vctx = mkctx_vim();
         let count = Count::Contextual;
 
         /*
@@ -4964,7 +4971,7 @@ mod tests {
     fn test_motion_screen_wrap() {
         let rope = EditRope::from("abcdefghij\nklmnopqrstuvwxyz\n");
         let mut vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
 
         vwctx.corner = Cursor::new(0, 0);
         vwctx.set_wrap(true);
@@ -5023,7 +5030,7 @@ mod tests {
     fn test_motion_screen_nowrap() {
         let rope = EditRope::from("abcdefghij\nklmnopqrstuvwxyz\n");
         let mut vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
 
         vwctx.corner = Cursor::new(0, 5);
         vwctx.set_wrap(false);
@@ -5076,7 +5083,7 @@ mod tests {
     fn test_motion_screen_first_word_wrap() {
         let rope = EditRope::from("abcde  f g  hij\n  klm  nop\n");
         let mut vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
 
         vwctx.set_wrap(true);
         vwctx.corner = Cursor::new(0, 5);
@@ -5108,7 +5115,7 @@ mod tests {
     fn test_motion_screen_first_word_nowrap() {
         let rope = EditRope::from("abcde  f g  hij\n  klm  nop\n");
         let mut vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
 
         vwctx.set_wrap(false);
         vwctx.corner = Cursor::new(0, 5);
@@ -5133,7 +5140,7 @@ mod tests {
     fn test_range_buffer() {
         let rope = EditRope::from("abcdef\nghijklmn\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let cw = TargetShape::LineWise;
         let count = Count::Contextual;
         let rt = RangeType::Buffer;
@@ -5160,7 +5167,7 @@ mod tests {
     fn test_range_number_base2() {
         let rope = EditRope::from("abc103g-458\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let cw = TargetShape::CharWise;
         let count = Count::Contextual;
 
@@ -5190,7 +5197,7 @@ mod tests {
     fn test_range_number_base8() {
         let rope = EditRope::from("abc103g-458\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let cw = TargetShape::CharWise;
         let count = Count::Contextual;
 
@@ -5228,7 +5235,7 @@ mod tests {
     fn test_range_number_base10() {
         let rope = EditRope::from("abc103g-458\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let cw = TargetShape::CharWise;
         let count = Count::Contextual;
 
@@ -5260,7 +5267,7 @@ mod tests {
     fn test_range_number_base16() {
         let rope = EditRope::from("abc103g-458\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let cw = TargetShape::CharWise;
         let count = Count::Contextual;
 
@@ -5288,7 +5295,7 @@ mod tests {
     fn test_range_whitespace() {
         let rope = EditRope::from("a   \t   b\nc  \t\n\n    d");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let cw = TargetShape::CharWise;
         let count = Count::Contextual;
         let inc = true;
@@ -5344,7 +5351,7 @@ mod tests {
     fn test_range_line() {
         let rope = EditRope::from("1 2 3\nhello world\n    foo bar\na b c d e f\n");
         let vwctx = ViewportContext::<Cursor>::default();
-        let mut vctx = EditContext::default();
+        let mut vctx = mkctx_vim();
         let cw = TargetShape::LineWise;
         let count = Count::Contextual;
         let rt = RangeType::Line;
@@ -5376,7 +5383,7 @@ mod tests {
     fn test_range_bracketed_start_at_paren() {
         let rope = EditRope::from("foo (1 ( (a) \")\" (b) ')' (c) ) 2 3) bar");
         let vwctx = ViewportContext::<Cursor>::default();
-        let mut vctx = EditContext::default();
+        let mut vctx = mkctx_vim();
         let cw = TargetShape::CharWise;
         let count = Count::Contextual;
         let rt = RangeType::Bracketed('(', ')');
@@ -5428,7 +5435,7 @@ mod tests {
     fn test_range_bracketed_forward() {
         let rope = EditRope::from("foo (1 ( (a) \")\" (b) ')' (c) ) 2 3) bar");
         let vwctx = ViewportContext::<Cursor>::default();
-        let mut vctx = EditContext::default();
+        let mut vctx = mkctx_vim();
         let cw = TargetShape::CharWise;
         let count = Count::Contextual;
         let rt = RangeType::Bracketed('(', ')');
@@ -5468,7 +5475,7 @@ mod tests {
     fn test_range_bracketed_backward() {
         let rope = EditRope::from("foo (1 ( (a) \")\" (b) ')' (c) ) 2 3) bar");
         let vwctx = ViewportContext::<Cursor>::default();
-        let mut vctx = EditContext::default();
+        let mut vctx = mkctx_vim();
         let cw = TargetShape::CharWise;
         let count = Count::Contextual;
         let rt = RangeType::Bracketed('(', ')');
@@ -5508,7 +5515,7 @@ mod tests {
     fn test_range_bracketed_no_surrounding_parens() {
         let rope = EditRope::from("foo (1 ( (a) \")\" (b) ')' (c) ) 2 3) bar");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let count = Count::Contextual;
         let rt = RangeType::Bracketed('(', ')');
         let inc = true;
@@ -5528,7 +5535,7 @@ mod tests {
     fn test_range_bracketed_exclusive() {
         let rope = EditRope::from("foo (1 ( (a) \")\" (b) ')' (c) ) 2 3) bar");
         let vwctx = ViewportContext::<Cursor>::default();
-        let mut vctx = EditContext::default();
+        let mut vctx = mkctx_vim();
         let cw = TargetShape::CharWise;
         let count = Count::Contextual;
         let rt = RangeType::Bracketed('(', ')');
@@ -5568,7 +5575,7 @@ mod tests {
     fn test_range_quoted() {
         let rope = EditRope::from("a b c 'd e f \\'g h i\\' j k' l m n 'o p' q");
         let vwctx = ViewportContext::<Cursor>::default();
-        let vctx = EditContext::default();
+        let vctx = mkctx_vim();
         let count = Count::Contextual;
         let rt = RangeType::Quote('\'');
         let cw = TargetShape::CharWise;

--- a/crates/modalkit/src/env/vim/keybindings.rs
+++ b/crates/modalkit/src/env/vim/keybindings.rs
@@ -2278,10 +2278,14 @@ mod tests {
         cmdbar_focus(s, CommandType::Search, search.into())
     }
 
+    fn mkctx() -> EditContext {
+        VimState::<EmptyInfo>::default().into()
+    }
+
     #[test]
     fn test_transitions_normal() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         let op = EditAction::Motion;
 
@@ -2407,7 +2411,7 @@ mod tests {
     #[test]
     fn test_transitions_command() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Starts in Normal mode
         assert_eq!(vm.mode(), VimMode::Normal);
@@ -2583,7 +2587,7 @@ mod tests {
     #[test]
     fn test_transitions_visual() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Move to Visual mode (charwise) and back using "v".
         ctx.target_shape = Some(TargetShape::CharWise);
@@ -2645,7 +2649,7 @@ mod tests {
     #[test]
     fn test_transitions_visual_select() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Test charwise shapes.
         ctx.target_shape = Some(TargetShape::CharWise);
@@ -2710,7 +2714,7 @@ mod tests {
     #[test]
     fn test_transitions_select() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Enter Select mode (charwise) via "gh".
         ctx.target_shape = Some(TargetShape::CharWise);
@@ -2789,7 +2793,7 @@ mod tests {
     #[test]
     fn test_count() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         let mov = mv!(MoveType::WordBegin(WordStyle::Little, MoveDir1D::Next));
 
@@ -2877,7 +2881,7 @@ mod tests {
     #[test]
     fn test_register() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         let op = EditAction::Yank;
         let mov = rangeop!(op, RangeType::Line);
@@ -2944,7 +2948,7 @@ mod tests {
     #[test]
     fn test_mark() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Create local mark 'c.
         let act = EditorAction::Mark(Specifier::Contextual);
@@ -2984,7 +2988,7 @@ mod tests {
     #[test]
     fn test_normal_ops() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         let mov = mv!(MoveType::WordBegin(WordStyle::Little, MoveDir1D::Next));
 
@@ -3099,7 +3103,7 @@ mod tests {
     #[test]
     fn test_delete_ops() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         let op = EditAction::Delete;
 
@@ -3136,7 +3140,7 @@ mod tests {
     #[test]
     fn test_change_ops() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Change a word around the cursor with "caw".
         let mov = range!(RangeType::Word(WordStyle::Little));
@@ -3241,7 +3245,7 @@ mod tests {
     #[test]
     fn test_normal_motion_charsearch() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         let same_target =
             EditTarget::Search(SearchType::Char(false), MoveDirMod::Same, Count::Contextual);
@@ -3313,7 +3317,7 @@ mod tests {
     #[test]
     fn test_normal_motion_special_key() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // <C-H>
         let mov = mv!(MoveType::Column(MoveDir1D::Previous, true));
@@ -3422,7 +3426,7 @@ mod tests {
     #[test]
     fn test_visual_ops() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Move into Visual mode (charwise)
         ctx.target_shape = Some(TargetShape::CharWise);
@@ -3639,7 +3643,7 @@ mod tests {
     #[test]
     fn test_visual_block_insert() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Move into Visual mode (blockwise)
         ctx.target_shape = Some(TargetShape::BlockWise);
@@ -3717,7 +3721,7 @@ mod tests {
     #[test]
     fn test_visual_motion() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         ctx.target_shape = Some(TargetShape::CharWise);
         vm.input_key(key!('v'));
@@ -3794,7 +3798,7 @@ mod tests {
     #[test]
     fn test_force_motion() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         let mov = mv!(MoveType::WordBegin(WordStyle::Little, MoveDir1D::Next));
 
@@ -3849,7 +3853,7 @@ mod tests {
     #[test]
     fn test_insert_mode() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         ctx.insert_style = Some(InsertStyle::Insert);
         ctx.last_column = true;
@@ -3960,7 +3964,7 @@ mod tests {
     #[test]
     fn test_insert_jk() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         ctx.insert_style = Some(InsertStyle::Insert);
         ctx.last_column = true;
@@ -3984,7 +3988,7 @@ mod tests {
     #[test]
     fn test_custom_operators() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         let step = InputStep::new().operator(EditAction::Delete, Some(VimMode::Insert));
         add_mapping(&mut vm, &NMAP, "R", &step);
@@ -4004,7 +4008,7 @@ mod tests {
     #[test]
     fn test_override() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Check the original Normal mode mapping.
         let mov = mv!(MoveType::ScreenLine(MoveDir1D::Next));
@@ -4053,7 +4057,7 @@ mod tests {
     #[test]
     fn test_count_alters_motion() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Without a count, "%" is ItemMatch.
         let mot = mv!(MoveType::ItemMatch);
@@ -4101,7 +4105,7 @@ mod tests {
     #[test]
     fn test_count_alters_window() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Without a count, ^Wo closes all windows besides the currently focused one.
         let target = WindowTarget::AllBut(FocusChange::Current);
@@ -4171,7 +4175,7 @@ mod tests {
     #[test]
     fn test_scrollcp() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Place cursored line at the top of the screen with "zt".
         let act = Action::Scroll(ScrollStyle::CursorPos(MovePosition::Beginning, Axis::Vertical));
@@ -4221,7 +4225,7 @@ mod tests {
     #[test]
     fn test_literal() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         ctx.insert_style = Some(InsertStyle::Insert);
         ctx.last_column = true;
@@ -4340,7 +4344,7 @@ mod tests {
     #[test]
     fn test_unmapped_reset() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         /*
          * The key "z" is not mapped in Operator Pending mode, so the action context should be
@@ -4367,7 +4371,7 @@ mod tests {
     #[test]
     fn test_count_nullifies() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         // Without a count, Delete deletes one character.
         let op = EditAction::Delete;
@@ -4390,7 +4394,7 @@ mod tests {
     #[test]
     fn test_macro_toggle() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         let toggle = Action::from(MacroAction::ToggleRecording);
 
@@ -4428,7 +4432,7 @@ mod tests {
     #[test]
     fn test_edit_repeat() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         let col = MoveType::Column(MoveDir1D::Next, false);
 
@@ -4557,7 +4561,7 @@ mod tests {
     #[test]
     fn test_edit_repeat_append_line() {
         let mut vm: VimMachine<TerminalKey> = default_vim_keys();
-        let mut ctx = EditContext::default();
+        let mut ctx = mkctx();
 
         let op = EditAction::Motion;
         let mov = mvop!(op, MoveType::LinePos(MovePosition::End), 0);


### PR DESCRIPTION
While looking into ulyssa/iamb#297, I think I've convinced myself that the default that `EditContext`/`EditContextBuilder` uses for `last_column` is wrong and a potential footgun that results in accidentally misusing `InsertTextAction` and others outside of a keybinding context. It should default to `true` so that building `Action` values from scratch don't unexpectedly clamp the cursor, but require explicitly requesting that behaviour via the builder interface.