### PR TITLE
Make workspace share Clippy configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -30,11 +33,8 @@ jobs:
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo build
-      uses: actions/cache@v3
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.9
     - name: Check formatting
       run: cargo +nightly fmt --all -- --check
     - name: Check Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ temp-dir = "0.1.11"
 thiserror = "^1.0.37"
 unicode-segmentation = "^1.7"
 unicode-width = "0.1.10"
+
+[workspace.lints.clippy]
+bool_assert_comparison = "allow"
+needless_return = "allow"

--- a/crates/keybindings/Cargo.toml
+++ b/crates/keybindings/Cargo.toml
@@ -15,3 +15,6 @@ rust-version.workspace = true
 textwrap = "^0.16"
 unicode-segmentation = { workspace = true }
 unicode-width = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/modalkit-ratatui/Cargo.toml
+++ b/crates/modalkit-ratatui/Cargo.toml
@@ -24,3 +24,6 @@ unicode-width = "0.2.0"
 [dev-dependencies]
 rand = { workspace = true }
 serde_json = "1.0.122"
+
+[lints]
+workspace = true

--- a/crates/modalkit/Cargo.toml
+++ b/crates/modalkit/Cargo.toml
@@ -37,3 +37,6 @@ unicode-width = { workspace = true }
 [dev-dependencies]
 rand = { workspace = true }
 temp-dir = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/modalkit/src/editing/cursor/choice.rs
+++ b/crates/modalkit/src/editing/cursor/choice.rs
@@ -124,7 +124,7 @@ mod tests {
         let c3 = Cursor::new(3, 5);
         let cw = TargetShape::CharWise;
 
-        for end in vec![CursorEnd::Start, CursorEnd::End, CursorEnd::Auto] {
+        for end in [CursorEnd::Start, CursorEnd::End, CursorEnd::Auto] {
             let choice = CursorChoice::Single(c0.clone());
             assert_eq!(choice.resolve(end).unwrap(), CursorState::Location(Cursor::new(0, 1)));
 

--- a/crates/modalkit/src/editing/key.rs
+++ b/crates/modalkit/src/editing/key.rs
@@ -263,16 +263,11 @@ mod tests {
         }
     }
 
-    #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, Hash, Eq, PartialEq)]
     enum TestMode {
+        #[default]
         Normal,
         Insert,
-    }
-
-    impl Default for TestMode {
-        fn default() -> Self {
-            TestMode::Normal
-        }
     }
 
     impl Mode<TestAction, VimState> for TestMode {}
@@ -298,18 +293,13 @@ mod tests {
         }
     }
 
-    #[derive(Clone, Debug, Eq, PartialEq)]
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
     enum TestAction {
         Macro(MacroAction),
         SetFlag(bool),
         Type(char),
+        #[default]
         NoOp,
-    }
-
-    impl Default for TestAction {
-        fn default() -> Self {
-            TestAction::NoOp
-        }
     }
 
     fn setup_recursive_bindings() -> (TestKeyManager, TestStore) {
@@ -321,35 +311,35 @@ mod tests {
         // Normal mode mappings
         bindings.add_mapping(
             TestMode::Normal,
-            &vec![(Once, Key("n".parse().unwrap()))],
+            &[(Once, Key("n".parse().unwrap()))],
             &TestAction::NoOp.into(),
         );
         bindings.add_mapping(
             TestMode::Normal,
-            &vec![(Once, Key("a".parse().unwrap()))],
+            &[(Once, Key("a".parse().unwrap()))],
             &TestAction::Macro(MacroAction::Run("n".into(), Count::Contextual)).into(),
         );
         bindings.add_mapping(
             TestMode::Normal,
-            &vec![(Once, Key("b".parse().unwrap()))],
+            &[(Once, Key("b".parse().unwrap()))],
             &TestAction::Macro(MacroAction::Run("aa".into(), Count::Contextual)).into(),
         );
         bindings.add_mapping(
             TestMode::Normal,
-            &vec![(Once, Key("c".parse().unwrap()))],
+            &[(Once, Key("c".parse().unwrap()))],
             &TestAction::Macro(MacroAction::Run("c".into(), Count::Contextual)).into(),
         );
 
         // Normal mode prefixes
         bindings.add_prefix(
             TestMode::Normal,
-            &vec![
+            &[
                 (Once, Key("\"".parse().unwrap())),
                 (Once, Class(CommonKeyClass::Register)),
             ],
             &None,
         );
-        bindings.add_prefix(TestMode::Normal, &vec![(Min(1), Class(CommonKeyClass::Count))], &None);
+        bindings.add_prefix(TestMode::Normal, &[(Min(1), Class(CommonKeyClass::Count))], &None);
 
         (TestKeyManager::new(bindings), store)
     }
@@ -363,7 +353,7 @@ mod tests {
         // Normal mode mappings
         bindings.add_mapping(
             TestMode::Normal,
-            &vec![
+            &[
                 (Once, Key("q".parse().unwrap())),
                 (Once, Key("q".parse().unwrap())),
                 (Once, Key("q".parse().unwrap())),
@@ -372,40 +362,40 @@ mod tests {
         );
         bindings.add_mapping(
             TestMode::Normal,
-            &vec![(Once, Key("@".parse().unwrap()))],
+            &[(Once, Key("@".parse().unwrap()))],
             &TestAction::Macro(MacroAction::Repeat(Count::Contextual)).into(),
         );
         bindings.add_mapping(
             TestMode::Normal,
-            &vec![(Once, Key("Q".parse().unwrap()))],
+            &[(Once, Key("Q".parse().unwrap()))],
             &TestAction::Macro(MacroAction::Execute(Count::Contextual)).into(),
         );
         bindings.add_mapping(
             TestMode::Normal,
-            &vec![(Once, Key("f".parse().unwrap()))],
+            &[(Once, Key("f".parse().unwrap()))],
             &TestAction::SetFlag(skip_confirm).into(),
         );
         bindings.add_mapping(
             TestMode::Normal,
-            &vec![(Once, Key("i".parse().unwrap()))],
+            &[(Once, Key("i".parse().unwrap()))],
             &TestMode::Insert.into(),
         );
 
         // Normal mode prefixes
         bindings.add_prefix(
             TestMode::Normal,
-            &vec![
+            &[
                 (Once, Key("\"".parse().unwrap())),
                 (Once, Class(CommonKeyClass::Register)),
             ],
             &None,
         );
-        bindings.add_prefix(TestMode::Normal, &vec![(Min(1), Class(CommonKeyClass::Count))], &None);
+        bindings.add_prefix(TestMode::Normal, &[(Min(1), Class(CommonKeyClass::Count))], &None);
 
         // Insert mode mappings
         bindings.add_mapping(
             TestMode::Insert,
-            &vec![(Once, Key("<Esc>".parse().unwrap()))],
+            &[(Once, Key("<Esc>".parse().unwrap()))],
             &TestMode::Normal.into(),
         );
 

--- a/crates/scansion/examples/read-loop.rs
+++ b/crates/scansion/examples/read-loop.rs
@@ -17,13 +17,15 @@ fn main() -> Result<(), std::io::Error> {
 
     loop {
         match rl.readline(Some("> ".to_string())) {
-            Ok(s) => match s.trim() {
-                "q" | "quit" => {
-                    return Ok(());
-                },
-                _ => {
-                    println!("User typed: {:?}", s);
-                },
+            Ok(s) => {
+                match s.trim() {
+                    "q" | "quit" => {
+                        return Ok(());
+                    },
+                    _ => {
+                        println!("User typed: {:?}", s);
+                    },
+                }
             },
             Err(e) => {
                 // Print out editor error messages.
@@ -38,10 +40,12 @@ fn select_mode() -> MixedChoice {
     let _ = args.next();
 
     match args.next() {
-        Some(arg) => match arg.as_str().trim() {
-            "e" | "emacs" => MixedChoice::Emacs,
-            "v" | "vim" => MixedChoice::Vim,
-            m => panic!("Unknown environment: {:?}", m),
+        Some(arg) => {
+            match arg.as_str().trim() {
+                "e" | "emacs" => MixedChoice::Emacs,
+                "v" | "vim" => MixedChoice::Vim,
+                m => panic!("Unknown environment: {:?}", m),
+            }
         },
         None => MixedChoice::Vim,
     }
@@ -54,7 +58,7 @@ fn create_readline(mode: MixedChoice) -> Result<ReadLine, std::io::Error> {
             EmacsBindings::default().submit_on_enter().setup(&mut emacs);
             ReadLine::new(emacs)
         },
-        MixedChoice::Vim | _ => {
+        _ => {
             let mut vi = VimMachine::<TerminalKey, ReadLineInfo>::empty();
             VimBindings::default().submit_on_enter().setup(&mut vi);
             ReadLine::new(vi)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.74"
+components = [ "clippy" ]


### PR DESCRIPTION
This adds a shared Clippy config, and updates it to allow a couple of the more pedantic lints.