### PR TITLE
Update `ratatui` dependency to `0.29.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "instability"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,23 +854,23 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.4.2",
  "cassowary",
  "compact_str",
  "crossterm",
+ "indoc",
  "instability",
  "itertools",
  "lru",
  "paste",
  "strum",
- "strum_macros",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1072,9 +1078,9 @@ checksum = "e9557cb6521e8d009c51a8666f09356f4b817ba9ba0981a305bd86aee47bd35c"
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]

--- a/crates/modalkit-ratatui/Cargo.toml
+++ b/crates/modalkit-ratatui/Cargo.toml
@@ -16,7 +16,7 @@ crossterm = { workspace = true }
 intervaltree = { workspace = true }
 libc = { workspace = true }
 modalkit = { workspace = true }
-ratatui = { version = "0.28.1" }
+ratatui = { version = "^0.29.0" }
 regex = { workspace = true }
 serde = { version = "^1.0", features = ["derive"] }
 unicode-width = "0.2.0"

--- a/crates/modalkit/Cargo.toml
+++ b/crates/modalkit/Cargo.toml
@@ -15,12 +15,11 @@ license.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["clipboard"]
+default = []
 clipboard = ["dep:arboard"]
 
 [dependencies]
 anymap2 = "0.13.0"
-arboard = { version = "^3.3.2", optional = true, features = ["wayland-data-control"] }
 bitflags = { workspace = true }
 crossterm = { workspace = true }
 derive_more = "0.99.16"
@@ -33,6 +32,11 @@ ropey = "1.5.0"
 thiserror = { workspace = true }
 unicode-segmentation = { workspace = true }
 unicode-width = { workspace = true }
+
+[dependencies.arboard]
+version = "^3.3.2"
+optional = true
+features = ["wayland-data-control"]
 
 [dev-dependencies]
 rand = { workspace = true }


### PR DESCRIPTION
This updates `modalkit-ratatui` to work with `ratatui@0.29.0` which is currently the most recent release.