### PR TITLE
Add `MatchAction` for regex filters

### DIFF
--- a/crates/editor-types/src/lib.rs
+++ b/crates/editor-types/src/lib.rs
@@ -128,10 +128,7 @@ pub enum SelectionAction {
     Expand(SelectionBoundary, TargetShapeFilter),
 
     /// Filter selections using the last regular expression entered for [CommandType::Search].
-    ///
-    /// The [bool] argument indicates whether we should drop selections that match instead of
-    /// keeping them.
-    Filter(bool),
+    Filter(MatchAction),
 
     /// Join adjacent selections together.
     Join,

--- a/crates/editor-types/src/prelude.rs
+++ b/crates/editor-types/src/prelude.rs
@@ -1280,13 +1280,7 @@ pub enum SelectionSplitStyle {
 
     /// Split a selection into [TargetShape::CharWise] parts based on the regular expression
     /// stored in the register for [CommandType::Search].
-    ///
-    /// When the [bool] argument is `false`, then text matching the regular expression will be
-    /// selected.
-    ///
-    /// When the [bool] argument is `true`, then text matching the regular expression will be
-    /// removed from the selections.
-    Regex(bool),
+    Regex(MatchAction),
 }
 
 /// Different ways to change the boundaries of a visual selection.
@@ -1509,6 +1503,37 @@ impl TargetShapeFilter {
             TargetShape::LineWise => self.contains(TargetShapeFilter::LINE),
             TargetShape::BlockWise => self.contains(TargetShapeFilter::BLOCK),
         }
+    }
+}
+
+impl From<TargetShape> for TargetShapeFilter {
+    fn from(shape: TargetShape) -> Self {
+        match shape {
+            TargetShape::CharWise => TargetShapeFilter::CHAR,
+            TargetShape::LineWise => TargetShapeFilter::LINE,
+            TargetShape::BlockWise => TargetShapeFilter::BLOCK,
+        }
+    }
+}
+
+/// Action to take on targets when filtering with a regular expression.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum MatchAction {
+    /// Keep targets of the regular expression.
+    Keep,
+    /// Remove targets of the regular expression.
+    Drop,
+}
+
+impl MatchAction {
+    /// Whether this action is [MatchAction::Keep].
+    pub fn is_keep(&self) -> bool {
+        matches!(self, MatchAction::Keep)
+    }
+
+    /// Whether this action is [MatchAction::Drop].
+    pub fn is_drop(&self) -> bool {
+        matches!(self, MatchAction::Drop)
     }
 }
 


### PR DESCRIPTION
This fixes a minor annoyance of mine (that the boolean for `SelectionAction::Filter` and `SelectionSplitStyle::Regex` is always non-intuitive to read) by adding a `MatchAction` type with `Keep` and `Drop` variants, which should hopefully make reading the intent a little clearer.