### PR TITLE
Add `KeywordTarget` argument to `KeywordLookup`

### DIFF
--- a/crates/editor-types/src/lib.rs
+++ b/crates/editor-types/src/lib.rs
@@ -540,7 +540,7 @@ pub enum Action<I: ApplicationInfo = EmptyInfo> {
     Scroll(ScrollStyle),
 
     /// Lookup the keyword under the cursor.
-    KeywordLookup,
+    KeywordLookup(KeywordTarget),
 
     /// Redraw the screen.
     RedrawScreen,
@@ -592,7 +592,7 @@ impl<I: ApplicationInfo> Action<I> {
             Action::Tab(_) => SequenceStatus::Break,
             Action::Window(_) => SequenceStatus::Break,
 
-            Action::KeywordLookup => SequenceStatus::Ignore,
+            Action::KeywordLookup(_) => SequenceStatus::Ignore,
             Action::NoOp => SequenceStatus::Ignore,
             Action::RedrawScreen => SequenceStatus::Ignore,
             Action::Scroll(_) => SequenceStatus::Ignore,
@@ -618,7 +618,7 @@ impl<I: ApplicationInfo> Action<I> {
             Action::Macro(_) => SequenceStatus::Atom,
             Action::Tab(_) => SequenceStatus::Atom,
             Action::Window(_) => SequenceStatus::Atom,
-            Action::KeywordLookup => SequenceStatus::Atom,
+            Action::KeywordLookup(_) => SequenceStatus::Atom,
             Action::NoOp => SequenceStatus::Atom,
             Action::Prompt(_) => SequenceStatus::Atom,
             Action::RedrawScreen => SequenceStatus::Atom,
@@ -643,7 +643,7 @@ impl<I: ApplicationInfo> Action<I> {
             Action::Macro(_) => SequenceStatus::Ignore,
             Action::Tab(_) => SequenceStatus::Ignore,
             Action::Window(_) => SequenceStatus::Ignore,
-            Action::KeywordLookup => SequenceStatus::Ignore,
+            Action::KeywordLookup(_) => SequenceStatus::Ignore,
             Action::NoOp => SequenceStatus::Ignore,
             Action::Prompt(_) => SequenceStatus::Ignore,
             Action::RedrawScreen => SequenceStatus::Ignore,
@@ -663,7 +663,7 @@ impl<I: ApplicationInfo> Action<I> {
 
             Action::CommandBar(_) => false,
             Action::Command(_) => false,
-            Action::KeywordLookup => false,
+            Action::KeywordLookup(_) => false,
             Action::Macro(_) => false,
             Action::NoOp => false,
             Action::Prompt(_) => false,

--- a/crates/editor-types/src/prelude.rs
+++ b/crates/editor-types/src/prelude.rs
@@ -576,6 +576,12 @@ impl BoundaryTest for WordStyle {
     }
 }
 
+impl From<Radix> for WordStyle {
+    fn from(radix: Radix) -> Self {
+        WordStyle::Number(radix)
+    }
+}
+
 /// Specify the base for a number.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Radix {
@@ -950,6 +956,22 @@ pub enum NumberChange {
 
     /// Increase the first number in the targeted text by [*n*](Count).
     Increase(Count),
+}
+
+/// Targets for [Action::KeywordLookup].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum KeywordTarget {
+    /// Lookup the [word][WordStyle] surrounding the cursor.
+    Word(WordStyle),
+
+    /// Lookup the currently selected text.
+    Selection,
+}
+
+impl From<WordStyle> for KeywordTarget {
+    fn from(style: WordStyle) -> KeywordTarget {
+        KeywordTarget::Word(style)
+    }
 }
 
 /// Targets for [WindowAction::Open] and [WindowAction::Switch].

--- a/crates/modalkit-ratatui/examples/editor.rs
+++ b/crates/modalkit-ratatui/examples/editor.rs
@@ -700,7 +700,7 @@ impl Editor {
                 None
             },
 
-            Action::KeywordLookup => {
+            Action::KeywordLookup(_) => {
                 // XXX: implement
                 None
             },

--- a/crates/modalkit-ratatui/src/cmdbar.rs
+++ b/crates/modalkit-ratatui/src/cmdbar.rs
@@ -298,7 +298,7 @@ mod tests {
         let act1 = Action::Suspend;
         let ctx1 = EditContextBuilder::default().search_regex_dir(MoveDir1D::Previous).build();
         cmdbar.set_type(":", CommandType::Command, &act1, &ctx1);
-        let act2 = Action::KeywordLookup;
+        let act2 = Action::KeywordLookup(KeywordTarget::Selection);
         let ctx2 = EditContextBuilder::default().search_regex_dir(MoveDir1D::Next).build();
         cmdbar.set_type(":", CommandType::Command, &act2, &ctx2);
 

--- a/crates/scansion/src/lib.rs
+++ b/crates/scansion/src/lib.rs
@@ -689,7 +689,7 @@ where
                 // XXX: implement
                 None
             },
-            Action::KeywordLookup => {
+            Action::KeywordLookup(_) => {
                 // XXX: implement
                 None
             },


### PR DESCRIPTION
I'm still not actually using `Action::KeywordLookup` anywhere, but while passing through the actions and keybindings, I realized that the difference in behaviour for `K` between Normal and Visual modes should be part of the returned `Action`, and not just something to be inferred from the context's target shape. This will also allow controlling what type of `WordStyle` is used in Normal mode.