### PR TITLE
Update workspace to Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 authors = ["Ulyssa <git@ulyssa.dev>"]
 repository = "https://github.com/ulyssa/modalkit"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.74"
 
 [workspace.dependencies.editor-types]


### PR DESCRIPTION
This updates the Rust edition for the workspace to 2021. Eventually I'll do the same for 2024.