### PR TITLE
Implementations of `Completer` should be `Send` and `Sync`

### DIFF
--- a/crates/modalkit/src/editing/completion.rs
+++ b/crates/modalkit/src/editing/completion.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 /// A trait for implementing custom completers for an application.
-pub trait Completer<I: ApplicationInfo> {
+pub trait Completer<I: ApplicationInfo>: Send + Sync {
     /// Complete the word just before [Cursor] inside the [EditRope].
     ///
     /// When this method returns, the [Cursor] should be updated to point at the

--- a/crates/modalkit/src/util.rs
+++ b/crates/modalkit/src/util.rs
@@ -1,5 +1,3 @@
-pub use editor_types::util::*;
-
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::ops::Bound;


### PR DESCRIPTION
Since the `Store` contains a `Box<dyn Completer<I>>`, this type should really always be `Send` and `Sync` so that the `Store` will always play nicely with multithreaded programs (like iamb).