### PR TITLE
`TextBox`: Fix cursor position for ambiguous character widths

### DIFF
--- a/crates/modalkit-ratatui/src/textbox.rs
+++ b/crates/modalkit-ratatui/src/textbox.rs
@@ -867,7 +867,7 @@ where
                     .map(|(i, _)| i)
                     .nth(cursor.x.saturating_sub(start))
                     .unwrap_or(s.len())]
-                    .width_cjk() as u16;
+                    .width() as u16;
 
                 state.term_cursor = (x + coff, y);
             }
@@ -1017,7 +1017,7 @@ where
                     .map(|(i, _)| i)
                     .nth(cursor.x.saturating_sub(start))
                     .unwrap_or(s.len())]
-                    .width_cjk() as u16;
+                    .width() as u16;
 
                 state.term_cursor = (x + coff, y);
             }
@@ -1080,7 +1080,7 @@ where
                         .map(|(i, _)| i)
                         .nth(cursor.x.saturating_sub(start))
                         .unwrap_or(s.len())]
-                        .width_cjk() as u16;
+                        .width() as u16;
 
                     state.term_cursor = (x + coff, y);
                 }


### PR DESCRIPTION
Box drawing characters like "┃" are reported as 2 characters wide when using `width_cjk` while they are rendered as 1 character wide.