### PR TITLE
Release modalkit{,-ratatui}@0.0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "modalkit"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "anymap2",
  "arboard",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "modalkit-ratatui"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "crossterm 0.29.0",
  "intervaltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ version = "0.0.2"
 
 [workspace.dependencies.modalkit]
 path = "crates/modalkit"
-version = "0.0.24"
+version = "0.0.25"
 
 [workspace.dependencies]
 bitflags = "2.4.2"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ used by adding `modalkit` to your dependencies in your project's `Cargo.toml`.
 
 ```toml
 [dependencies]
-modalkit = "0.0.24"
+modalkit = "0.0.25"
 ```
 
 ## License

--- a/crates/modalkit-ratatui/Cargo.toml
+++ b/crates/modalkit-ratatui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modalkit-ratatui"
-version = "0.0.24"
+version = "0.0.25"
 homepage = "https://github.com/ulyssa/modalkit/tree/main/crates/modalkit-ratatui"
 description = "A library for building TUI applications that use modal editing"
 keywords = ["modal", "ratatui", "tui"]

--- a/crates/modalkit-ratatui/README.md
+++ b/crates/modalkit-ratatui/README.md
@@ -18,7 +18,7 @@ your project's `Cargo.toml`.
 
 ```toml
 [dependencies]
-modalkit-ratatui = "0.0.24"
+modalkit-ratatui = "0.0.25"
 ```
 
 ## License

--- a/crates/modalkit/Cargo.toml
+++ b/crates/modalkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modalkit"
-version = "0.0.24"
+version = "0.0.25"
 homepage = "https://github.com/ulyssa/modalkit/tree/main/crates/modalkit"
 readme = "README.md"
 description = "A library for building applications that use modal editing"

--- a/crates/modalkit/README.md
+++ b/crates/modalkit/README.md
@@ -21,7 +21,7 @@ project's `Cargo.toml`.
 
 ```toml
 [dependencies]
-modalkit = "0.0.24"
+modalkit = "0.0.25"
 ```
 
 ## License


### PR DESCRIPTION
This releases v0.0.25 of `modalkit` and `modalkit-ratatui`. This release contains:

- #182
- #183
- #185
- #191
- #194
- #195
