### PR TITLE
Add `set_ignorecase` to `ListState` and `TextBoxState`

### DIFF
--- a/crates/modalkit-ratatui/src/list.rs
+++ b/crates/modalkit-ratatui/src/list.rs
@@ -31,7 +31,7 @@
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::marker::PhantomData;
 
-use regex::Regex;
+use regex::{Regex, RegexBuilder};
 
 use ratatui::{
     buffer::Buffer,
@@ -159,6 +159,7 @@ where
     items: Vec<T>,
     cursor: ListCursor,
     viewctx: ViewportContext<ListCursor>,
+    ignorecase: bool,
 
     /// Tracks the jumplist for this window.
     jumped: HistoryList<ListCursor>,
@@ -192,6 +193,7 @@ where
             items,
             cursor: 0.into(),
             viewctx,
+            ignorecase: false,
             jumped: HistoryList::new(0.into(), 100),
         }
     }
@@ -322,6 +324,11 @@ where
     /// Set the dimensions and placement within the terminal window for this list.
     pub fn set_term_info(&mut self, area: Rect) {
         self.viewctx.dimensions = (area.width as usize, area.height as usize);
+    }
+
+    /// Set whether regular expression searches ignore case.
+    pub fn set_ignorecase(&mut self, ignorecase: bool) {
+        self.ignorecase = ignorecase;
     }
 }
 
@@ -630,7 +637,9 @@ where
 
                         let lsearch = store.registers.get_last_search();
                         let lsearch = lsearch.to_string();
-                        let needle = Regex::new(lsearch.as_ref())?;
+                        let needle = RegexBuilder::new(lsearch.as_ref())
+                            .case_insensitive(self.ignorecase)
+                            .build()?;
 
                         self.find_regex(&self.cursor, dir, &needle, count).map(|r| r.start)
                     },
@@ -696,7 +705,9 @@ where
 
                         let lsearch = store.registers.get_last_search();
                         let lsearch = lsearch.to_string();
-                        let needle = Regex::new(lsearch.as_ref())?;
+                        let needle = RegexBuilder::new(lsearch.as_ref())
+                            .case_insensitive(self.ignorecase)
+                            .build()?;
 
                         self.find_regex(&self.cursor, dir, &needle, count)
                     },
@@ -1153,6 +1164,7 @@ where
             items: self.items.clone(),
             cursor: self.cursor.clone(),
             viewctx: self.viewctx.clone(),
+            ignorecase: self.ignorecase,
             jumped: self.jumped.clone(),
         }
     }
@@ -1639,6 +1651,25 @@ mod tests {
 
         list.search(MoveDir1D::Previous.into(), 2.into(), &ctx, &mut store)
             .unwrap();
+        assert_eq!(list.cursor.position, 7);
+    }
+
+    #[test]
+    fn test_search_ignorecase() {
+        let (mut list, ctx, mut store) = mklist();
+
+        // "MONDAY" does not appear with this casing in any title.
+        store.registers.set_last_search("MONDAY");
+
+        assert_eq!(list.cursor.position, 0);
+
+        // Case-sensitive by default: no match, so the cursor stays put.
+        list.search(MoveDir1D::Next.into(), 1.into(), &ctx, &mut store).unwrap();
+        assert_eq!(list.cursor.position, 0);
+
+        // With ignorecase, "MONDAY" matches "Monday Starts on Saturday" (item 7).
+        list.set_ignorecase(true);
+        list.search(MoveDir1D::Next.into(), 1.into(), &ctx, &mut store).unwrap();
         assert_eq!(list.cursor.position, 7);
     }
 

--- a/crates/modalkit-ratatui/src/list.rs
+++ b/crates/modalkit-ratatui/src/list.rs
@@ -1658,16 +1658,14 @@ mod tests {
     fn test_search_ignorecase() {
         let (mut list, ctx, mut store) = mklist();
 
-        // "MONDAY" does not appear with this casing in any title.
+        // "MONDAY" only matches "Monday Starts on Saturday" (item 7) when case is ignored.
         store.registers.set_last_search("MONDAY");
 
         assert_eq!(list.cursor.position, 0);
 
-        // Case-sensitive by default: no match, so the cursor stays put.
         list.search(MoveDir1D::Next.into(), 1.into(), &ctx, &mut store).unwrap();
         assert_eq!(list.cursor.position, 0);
 
-        // With ignorecase, "MONDAY" matches "Monday Starts on Saturday" (item 7).
         list.set_ignorecase(true);
         list.search(MoveDir1D::Next.into(), 1.into(), &ctx, &mut store).unwrap();
         assert_eq!(list.cursor.position, 7);

--- a/crates/modalkit-ratatui/src/textbox.rs
+++ b/crates/modalkit-ratatui/src/textbox.rs
@@ -223,6 +223,11 @@ where
         self.readonly = readonly;
     }
 
+    /// Set whether regular expression searches ignore case.
+    pub fn set_ignorecase(&mut self, ignorecase: bool) {
+        self.buffer.write().unwrap().set_ignorecase(ignorecase);
+    }
+
     /// Get the contents of the underlying buffer as an [EditRope].
     pub fn get(&self) -> EditRope {
         self.buffer.read().unwrap().get().clone()

--- a/crates/modalkit/src/editing/buffer/mod.rs
+++ b/crates/modalkit/src/editing/buffer/mod.rs
@@ -18,7 +18,7 @@ use std::collections::vec_deque::VecDeque;
 use std::marker::PhantomData;
 use std::ops::Range;
 
-use regex::Regex;
+use regex::{Regex, RegexBuilder};
 
 use crate::errors::{EditError, EditResult, UIResult};
 use crate::prelude::*;
@@ -114,6 +114,8 @@ pub struct EditBuffer<I: ApplicationInfo> {
 
     push_next_change: bool,
 
+    ignorecase: bool,
+
     _p: PhantomData<I>,
 }
 
@@ -163,6 +165,7 @@ where
             completions: HashMap::new(),
             lines: LineCompleter::default(),
             push_next_change: true,
+            ignorecase: false,
             _p: PhantomData,
         }
     }
@@ -180,6 +183,11 @@ where
     /// Get this buffer's content identifier.
     pub fn id(&self) -> I::ContentId {
         self.id.clone()
+    }
+
+    /// Set whether regular expression searches ignore case.
+    pub fn set_ignorecase(&mut self, ignorecase: bool) {
+        self.ignorecase = ignorecase;
     }
 
     fn _char(&self, c: Char, cursor: &Cursor, digraphs: &DigraphStore) -> EditResult<char, I> {
@@ -361,11 +369,14 @@ where
             .ok_or(EditError::NoCursorWord)?;
         let word = regex::escape(word.to_string().as_str());
 
-        let needle = if boundary {
-            Regex::new(format!("\\b{word}\\b").as_str())
+        let pattern = if boundary {
+            format!("\\b{word}\\b")
         } else {
-            Regex::new(word.as_str())
-        }?;
+            word
+        };
+        let needle = RegexBuilder::new(pattern.as_str())
+            .case_insensitive(self.ignorecase)
+            .build()?;
 
         store.registers.set_last_command(CommandType::Search, needle.to_string());
 
@@ -398,7 +409,9 @@ where
 
     fn _get_regex(&self, store: &Store<I>) -> EditResult<Regex, I> {
         let lsearch = store.registers.get_last_search();
-        let regex = Regex::new(lsearch.to_string().as_ref())?;
+        let regex = RegexBuilder::new(lsearch.to_string().as_ref())
+            .case_insensitive(self.ignorecase)
+            .build()?;
 
         return Ok(regex);
     }
@@ -2075,6 +2088,27 @@ mod tests {
         vctx.action.count = Some(1);
         edit!(ebuf, op, mv, ctx!(gid, vwctx, vctx), store);
         assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 0));
+    }
+
+    #[test]
+    fn test_search_regex_ignorecase() {
+        let (mut ebuf, gid, vwctx, mut vctx, mut store) =
+            mkfivestr("hello world\nhelp helm writhe\nwhisk helium\n");
+
+        let op = EditAction::Motion;
+        let mv = EditTarget::Search(SearchType::Regex, MoveDirMod::Same, Count::Contextual);
+
+        // "HE" only matches "he" when case is ignored.
+        store.registers.set_last_search("HE");
+        ebuf.set_leader(gid, Cursor::new(0, 6));
+        vctx.action.count = Some(1);
+
+        edit!(ebuf, op, mv, ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 6));
+
+        ebuf.set_ignorecase(true);
+        edit!(ebuf, op, mv, ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 0));
     }
 
     #[test]


### PR DESCRIPTION
Adds a `set_ignorecase` setter to `ListState` so consumers can make regex searches case-insensitive. Defaults to off, so existing behavior is unchanged.

Motivated by ulyssa/iamb#628, where the list-search case folding is currently worked around per item.