### PR TITLE
Fix entering characters at end of line in Replace mode

### DIFF
--- a/crates/modalkit-ratatui/examples/editor.rs
+++ b/crates/modalkit-ratatui/examples/editor.rs
@@ -1,5 +1,6 @@
 use std::collections::hash_map::{Entry, HashMap};
 use std::collections::VecDeque;
+use std::fmt;
 use std::fs::{DirEntry, File, FileType};
 use std::io::{stdout, Stdout};
 use std::path::Path;
@@ -80,9 +81,9 @@ struct DirectoryItem {
     entry: String,
 }
 
-impl ToString for DirectoryItem {
-    fn to_string(&self) -> String {
-        return self.entry.clone();
+impl fmt::Display for DirectoryItem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.entry)
     }
 }
 

--- a/crates/modalkit/src/editing/buffer/complete.rs
+++ b/crates/modalkit/src/editing/buffer/complete.rs
@@ -618,7 +618,7 @@ mod tests {
             &mut store,
         )
         .unwrap();
-        assert_eq!(unescape(ebuf.get_text().trim_end()), format!("text {}", file1));
+        assert_eq!(unescape(ebuf.get_text().trim_end()), format!("text {file1}"));
     }
 
     #[test]

--- a/crates/modalkit/src/editing/buffer/edit.rs
+++ b/crates/modalkit/src/editing/buffer/edit.rs
@@ -20,6 +20,7 @@ where
     fn delete(
         &mut self,
         range: &CursorRange,
+        change_start: Option<&Cursor>,
         ctx: &C,
         store: &mut Store<I>,
     ) -> EditResult<(CursorChoice, Vec<CursorAdjustment>), I>;
@@ -88,6 +89,7 @@ where
     fn delete(
         &mut self,
         range: &CursorRange,
+        change_start: Option<&Cursor>,
         ctx: &CursorMovementsContext<'a, Cursor>,
         store: &mut Store<I>,
     ) -> EditResult<(CursorChoice, Vec<CursorAdjustment>), I> {
@@ -113,15 +115,21 @@ where
 
             deleted = text + deleted;
 
-            match style {
-                InsertStyle::Insert => {
+            match (style, change_start) {
+                (InsertStyle::Insert, _) | (InsertStyle::Replace, None) => {
                     self.text = prefix + suffix;
                 },
-                InsertStyle::Replace => {
+                (InsertStyle::Replace, Some(c)) => {
                     let current = self.history.current();
-                    let restore = current.slice(into_range(start, end, inclusive));
+                    let colmax = current.max_column_idx(c.y, true);
+                    let offmax = current.lincol_to_offset(c.y, colmax);
 
-                    self.text = prefix + restore + suffix;
+                    if c.y == range.end.y && start <= offmax {
+                        let restore = current.slice(into_range(start, end.min(offmax), inclusive));
+                        self.text = prefix + restore + suffix;
+                    } else {
+                        self.text = prefix + suffix;
+                    }
                 },
             }
 

--- a/crates/modalkit/src/editing/buffer/insert_text.rs
+++ b/crates/modalkit/src/editing/buffer/insert_text.rs
@@ -72,8 +72,7 @@ where
 
         let gid = ctx.0;
         let mut group = self.get_group(gid);
-
-        self.push_change(&group);
+        let change_start = group.clone();
 
         for state in group.iter_mut() {
             let (choice, adjs) = match style {
@@ -115,6 +114,7 @@ where
             }
         }
 
+        self.push_change(change_start);
         self.set_group(gid, group);
 
         Ok(None)
@@ -134,8 +134,7 @@ where
 
         let gid = ctx.0;
         let mut group = self.get_group(gid);
-
-        self.push_change(&group);
+        let change_start = group.clone();
 
         for state in group.iter_mut() {
             let (choice, adjs) = self.text.paste(state.cursor(), dir, text.clone(), shape);
@@ -148,6 +147,7 @@ where
             }
         }
 
+        self.push_change(change_start);
         self.set_group(gid, group);
 
         Ok(None)
@@ -169,9 +169,8 @@ where
         let mut group = self.get_group(gid);
         let mut adjs = vec![];
 
+        let change_start = group.clone();
         let text = EditRope::from(s).repeat(TargetShape::CharWise, count);
-
-        self.push_change(&group);
 
         for state in group.iter_mut() {
             state.adjust(adjs.as_slice());
@@ -189,6 +188,7 @@ where
         }
 
         self._adjust_all(adjs, store);
+        self.push_change(change_start);
         self.set_group(gid, group);
 
         Ok(None)
@@ -208,8 +208,7 @@ where
 
         let gid = ctx.0;
         let mut group = self.get_group(gid);
-
-        self.push_change(&group);
+        let change_start = group.clone();
 
         let mut typed: Vec<&mut CursorState> = vec![];
         let mut adjs = vec![];
@@ -241,6 +240,7 @@ where
         }
 
         self._adjust_all(adjs, store);
+        self.push_change(change_start);
         self.set_group(gid, group);
 
         Ok(None)
@@ -408,10 +408,141 @@ mod tests {
         assert_eq!(ebuf.get_text(), "calyx\n");
         assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 5));
 
+        type_char!(ebuf, 'e', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxe\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 6));
+
+        type_char!(ebuf, 's', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 7));
+
         let mov = MoveType::WordBegin(WordStyle::Little, MoveDir1D::Previous);
 
         edit!(ebuf, EditAction::Delete, mv!(mov), ctx!(gid, vwctx, vctx), store);
         assert_eq!(ebuf.get_text(), "hello\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 0));
+    }
+
+    #[test]
+    fn test_typing_replace_multiline() {
+        let (mut ebuf, gid, vwctx, mut vctx, mut store) = mkfivestr("hello\nworld");
+
+        vctx.persist.insert = Some(InsertStyle::Replace);
+
+        type_char!(ebuf, 'c', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "cello\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 1));
+
+        type_char!(ebuf, 'a', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "callo\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 2));
+
+        type_char!(ebuf, 'l', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "callo\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 3));
+
+        type_char!(ebuf, 'y', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyo\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 4));
+
+        type_char!(ebuf, 'x', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyx\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 5));
+
+        type_char!(ebuf, 'e', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxe\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 6));
+
+        type_char!(ebuf, 's', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 7));
+
+        type_char!(ebuf, '\n', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\n\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 0));
+
+        type_char!(ebuf, 'a', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\na\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 1));
+
+        type_char!(ebuf, 'b', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\nab\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 2));
+
+        type_char!(ebuf, 'c', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\nabc\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 3));
+
+        type_char!(ebuf, 'd', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\nabcd\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 4));
+
+        type_char!(ebuf, 'e', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\nabcde\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 5));
+
+        type_char!(ebuf, 'f', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\nabcdef\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 6));
+
+        type_char!(ebuf, 'g', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\nabcdefg\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 7));
+
+        type_char!(ebuf, 'h', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\nabcdefgh\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 8));
+
+        type_char!(ebuf, 'i', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\nabcdefghi\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 9));
+
+        type_char!(ebuf, 'j', gid, vwctx, vctx, store);
+        assert_eq!(ebuf.get_text(), "calyxes\nabcdefghij\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 10));
+
+        let mov = MoveType::WordBegin(WordStyle::Little, MoveDir1D::Previous);
+
+        edit!(ebuf, EditAction::Delete, mv!(mov), ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_text(), "calyxes\n\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 0));
+
+        let mov = MoveType::Column(MoveDir1D::Previous, true);
+
+        edit!(ebuf, EditAction::Delete, mv!(mov), ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_text(), "calyxes\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 7));
+
+        edit!(ebuf, EditAction::Delete, mv!(mov), ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_text(), "calyxe\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 6));
+
+        edit!(ebuf, EditAction::Delete, mv!(mov), ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_text(), "calyx\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 5));
+
+        edit!(ebuf, EditAction::Delete, mv!(mov), ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_text(), "calyo\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 4));
+
+        edit!(ebuf, EditAction::Delete, mv!(mov), ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_text(), "callo\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 3));
+
+        edit!(ebuf, EditAction::Delete, mv!(mov), ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_text(), "callo\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 2));
+
+        edit!(ebuf, EditAction::Delete, mv!(mov), ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_text(), "cello\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 1));
+
+        edit!(ebuf, EditAction::Delete, mv!(mov), ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_text(), "hello\nworld\n");
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 0));
+
+        edit!(ebuf, EditAction::Delete, mv!(mov), ctx!(gid, vwctx, vctx), store);
+        assert_eq!(ebuf.get_text(), "hello\nworld\n");
         assert_eq!(ebuf.get_leader(gid), Cursor::new(0, 0));
     }
 

--- a/crates/modalkit/src/editing/buffer/mod.rs
+++ b/crates/modalkit/src/editing/buffer/mod.rs
@@ -782,7 +782,7 @@ where
         self.text.chars_until(start, end).collect::<String>().into()
     }
 
-    fn push_change(&mut self, group: &CursorGroup) {
+    fn push_change(&mut self, group: CursorGroup) {
         if !self.push_next_change {
             return;
         }
@@ -794,7 +794,7 @@ where
             }
         }
 
-        self.changed.push_back(group.clone());
+        self.changed.push_back(group);
         self.push_next_change = false;
 
         while self.changed.len() > 100 {
@@ -1084,14 +1084,24 @@ where
         let gid = ictx.0;
         let end = ctx.context.get_cursor_end();
         let mut group = self.get_group(gid);
+        let change_start = group.clone();
         let mut adjs = vec![];
 
+        // Iterate over where the cursors were when editing started:
+        let changed_start = self.changed.back().cloned();
+        let mut changed_iter = changed_start.as_ref().map(CursorGroup::iter).unwrap_or_default();
+
         for state in group.iter_mut() {
+            let changed = changed_iter.next();
+
             state.adjust(adjs.as_slice());
 
             let (choice, mut adjustments) = match (self._target(state, target, ctx, store)?, action)
             {
-                (Some(range), EditAction::Delete) => self.delete(&range, ctx, store)?,
+                (Some(range), EditAction::Delete) => {
+                    let change_start = changed.map(|c| c.cursor());
+                    self.delete(&range, change_start, ctx, store)?
+                },
                 (Some(range), EditAction::Join(spaces)) => {
                     self.join(*spaces, &range, ctx, store)?
                 },
@@ -1130,7 +1140,7 @@ where
         }
 
         self._adjust_all(adjs, store);
-        self.push_change(&group);
+        self.push_change(change_start);
         self.set_group(gid, group);
 
         Ok(None)
@@ -1852,26 +1862,26 @@ mod tests {
         assert_eq!(ebuf.get_leader(gid), Cursor::new(4, 4));
         assert_eq!(ebuf.get_text(), "12345\n   7890\nabce\nfgh1ij\n klmno\n");
 
-        // Go back once to (3, 4).
+        // Go back once to (3, 3).
         let count = ebuf.jump(cl, prev, 1, ctx!(gid, vwctx, vctx)).unwrap();
         assert_eq!(count, 0);
-        assert_eq!(ebuf.get_leader(gid), Cursor::new(3, 4));
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(3, 3));
 
         // Go back once to (1, 3).
         let count = ebuf.jump(cl, prev, 1, ctx!(gid, vwctx, vctx)).unwrap();
         assert_eq!(count, 0);
         assert_eq!(ebuf.get_leader(gid), Cursor::new(1, 3));
 
-        // Go forward once to (3, 4) again.
+        // Go forward once to (3, 3) again.
         let count = ebuf.jump(cl, next, 1, ctx!(gid, vwctx, vctx)).unwrap();
         assert_eq!(count, 0);
-        assert_eq!(ebuf.get_leader(gid), Cursor::new(3, 4));
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(3, 3));
 
         // Can't go forward any more: original position is not saved in changelist, like it is w/
         // the jumplist.
         let count = ebuf.jump(cl, next, 1, ctx!(gid, vwctx, vctx)).unwrap();
         assert_eq!(count, 0);
-        assert_eq!(ebuf.get_leader(gid), Cursor::new(3, 4));
+        assert_eq!(ebuf.get_leader(gid), Cursor::new(3, 3));
     }
 
     #[test]

--- a/crates/modalkit/src/editing/cursor/group.rs
+++ b/crates/modalkit/src/editing/cursor/group.rs
@@ -21,6 +21,7 @@ pub enum CursorGroupCombineError {
 }
 
 /// Iterate over references to [CursorState] values within a [CursorGroup].
+#[derive(Default)]
 pub struct CursorGroupIter<'a> {
     members: std::vec::IntoIter<&'a CursorState>,
     leader: Option<&'a CursorState>,

--- a/crates/modalkit/src/editing/rope/mod.rs
+++ b/crates/modalkit/src/editing/rope/mod.rs
@@ -1346,7 +1346,9 @@ impl EditRope {
 
         match style {
             InsertStyle::Replace => {
-                self.rope.remove(ioff.0..ioff.0 + tlen);
+                let offmax = self.lincol_to_offset(cursor.y, colmax);
+                let eoff = offmax.0.min(ioff.0 + tlen);
+                self.rope.remove(ioff.0..eoff);
                 self._insert_at(ioff.0, text.rope);
             },
             InsertStyle::Insert => {
@@ -1612,7 +1614,7 @@ impl EditRope {
         RopeCursor::new(self, off.0)
     }
 
-    fn lincol_to_offset(&self, line: usize, col: usize) -> CharOff {
+    pub(crate) fn lincol_to_offset(&self, line: usize, col: usize) -> CharOff {
         self.offset_of_line(line) + CharOff(col)
     }
 


### PR DESCRIPTION
This resolves #206 by fixing several issues:

* Inserting into `EditRope` at the end of the line should continue inserting into the line, and not replace continue replacing bytes like the newline, or be stopped by the final character at the end of the buffer.
* Using backspace to restore characters should only pull text from the most recent history checkpoint once the cursor has moved back into the range of the replaced characters.
* Changelist entries need to be inserted after cursor adjustments are made, so that they do not get adjutsed.