### PR TITLE
Allow applications to set the default register for storing text

### DIFF
--- a/crates/modalkit-ratatui/src/list.rs
+++ b/crates/modalkit-ratatui/src/list.rs
@@ -738,7 +738,9 @@ where
                     }
 
                     let cell = RegisterCell::new(TargetShape::LineWise, yanked);
-                    let register = ctx.get_register().unwrap_or(Register::Unnamed);
+                    let register = ctx
+                        .get_register()
+                        .unwrap_or_else(|| store.registers.get_default_register());
                     let mut flags = RegisterPutFlags::NONE;
 
                     if ctx.get_register_append() {

--- a/crates/modalkit/src/editing/buffer/edit.rs
+++ b/crates/modalkit/src/editing/buffer/edit.rs
@@ -149,7 +149,10 @@ where
         self.text.trailing_newline();
 
         let cell = RegisterCell::new(shape, deleted);
-        let register = ctx.context.get_register().unwrap_or(Register::Unnamed);
+        let register = ctx
+            .context
+            .get_register()
+            .unwrap_or_else(|| store.registers.get_default_register());
         let mut flags = RegisterPutFlags::DELETE;
 
         if ctx.context.get_register_append() {
@@ -191,7 +194,10 @@ where
         }
 
         let cell = RegisterCell::new(shape, yanked);
-        let register = ctx.context.get_register().unwrap_or(Register::Unnamed);
+        let register = ctx
+            .context
+            .get_register()
+            .unwrap_or_else(|| store.registers.get_default_register());
         let mut flags = RegisterPutFlags::NONE;
 
         if ctx.context.get_register_append() {

--- a/crates/modalkit/src/editing/buffer/insert_text.rs
+++ b/crates/modalkit/src/editing/buffer/insert_text.rs
@@ -116,7 +116,11 @@ where
     ) -> EditResult<EditInfo, I> {
         let count = ctx.2.resolve(count);
         let insty = ctx.2.get_insert_style();
-        let cell = store.registers.get(&ctx.2.get_register().unwrap_or(Register::Unnamed))?;
+        let register = ctx
+            .2
+            .get_register()
+            .unwrap_or_else(|| store.registers.get_default_register());
+        let cell = store.registers.get(&register)?;
         let text = cell.value.repeat(cell.shape, count);
 
         self.cursor_insert(true, ctx, store, |state, buf, _| {

--- a/crates/modalkit/src/editing/store/register.rs
+++ b/crates/modalkit/src/editing/store/register.rs
@@ -125,6 +125,8 @@ struct CommandHistory {
 /// [EditAction::Yank]: crate::actions::EditAction::Yank
 /// [MacroAction::ToggleRecording]: crate::actions::MacroAction::ToggleRecording
 pub struct RegisterStore {
+    default_text: Register,
+
     last_commands: HashMap<CommandType, CommandHistory>,
 
     altbufname: RegisterCell,
@@ -230,6 +232,8 @@ impl From<(TargetShape, &str)> for RegisterCell {
 impl RegisterStore {
     fn new() -> Self {
         RegisterStore {
+            default_text: Register::Unnamed,
+
             last_commands: HashMap::default(),
 
             altbufname: RegisterCell::default(),
@@ -249,6 +253,16 @@ impl RegisterStore {
             #[cfg(feature = "clipboard")]
             clipboard: Clipboard::new().ok().map(RefCell::new),
         }
+    }
+
+    /// Returns the default register to use for storing text.
+    pub fn get_default_register(&self) -> Register {
+        self.default_text.clone()
+    }
+
+    /// Change the default register to use for storing text.
+    pub fn set_default_register(&mut self, r: Register) {
+        self.default_text = r;
     }
 
     #[cfg(feature = "clipboard")]


### PR DESCRIPTION
This allows the `RegisterStore` to track and contain a default register to use when storing or fetching text.

resolves #180 