### PR TITLE
Add option to disable `submit_on_enter` in Insert mode for Vim keybindings

### DIFF
--- a/crates/modalkit/src/env/vim/keybindings.rs
+++ b/crates/modalkit/src/env/vim/keybindings.rs
@@ -1888,8 +1888,8 @@ fn default_ctrlcd<I: ApplicationInfo>() -> Vec<(MappedModes, &'static str, Input
 }
 
 #[rustfmt::skip]
-fn submit_on_enter<I: ApplicationInfo>() -> Vec<(MappedModes, &'static str, InputStep<I>)> {
-    [
+fn submit_on_enter<I: ApplicationInfo>(insert_mode_newline: bool) -> Vec<(MappedModes, &'static str, InputStep<I>)> {
+    let mut mappings = [
         // <Enter> in Normal and Visual mode submits contents.
         ( NVMAP, "<Enter>", prompt!(PromptAction::Submit, VimMode::Normal) ),
 
@@ -1901,7 +1901,21 @@ fn submit_on_enter<I: ApplicationInfo>() -> Vec<(MappedModes, &'static str, Inpu
 
         // <Enter> in Operator-Pending mode moves to the next line.
         ( OMAP, "<Enter>", edit_end!(MoveType::FirstWord(MoveDir1D::Next)) ),
-    ].to_vec()
+    ].to_vec();
+
+    if insert_mode_newline {
+        // <Enter> in Insert mode types a newlines.
+        mappings.push(
+            ( IMAP, "<Enter>", chartype!(Char::Single('\n')) ),
+        );
+    } else {
+        // <Enter> in Insert mode submits contents and stays in Insert mode.
+        mappings.push(
+            ( IMAP, "<Enter>", prompt!(PromptAction::Submit, VimMode::Insert) ),
+        );
+    }
+
+    mappings
 }
 
 #[rustfmt::skip]
@@ -1995,10 +2009,13 @@ pub struct VimBindings<I: ApplicationInfo> {
 }
 
 impl<I: ApplicationInfo> VimBindings<I> {
-    /// Remap the Enter key in Normal, Visual, Select, and Insert mode to
-    /// [submit](PromptAction::Submit) instead.
-    pub fn submit_on_enter(mut self) -> Self {
-        self.enter = submit_on_enter();
+    /// Remap the Enter key in Normal, Visual, and Select mode to [submit](PromptAction::Submit)
+    /// instead.
+    ///
+    /// `insert_mode_newline` decides whether Enter in Insert mode adds a newline as usual or
+    /// triggers [submit](PromptAction::Submit) as well.
+    pub fn submit_on_enter(mut self, insert_mode_newline: bool) -> Self {
+        self.enter = submit_on_enter(insert_mode_newline);
         self
     }
 
@@ -2029,7 +2046,7 @@ impl<I: ApplicationInfo> VimBindings<I> {
 
 impl<I: ApplicationInfo> ShellBindings for VimBindings<I> {
     fn shell(self) -> Self {
-        self.submit_on_enter().search_is_action().ctrlcd_is_abort()
+        self.submit_on_enter(false).search_is_action().ctrlcd_is_abort()
     }
 }
 

--- a/crates/scansion/examples/read-loop.rs
+++ b/crates/scansion/examples/read-loop.rs
@@ -60,7 +60,7 @@ fn create_readline(mode: MixedChoice) -> Result<ReadLine, std::io::Error> {
         },
         _ => {
             let mut vi = VimMachine::<TerminalKey, ReadLineInfo>::empty();
-            VimBindings::default().submit_on_enter().setup(&mut vi);
+            VimBindings::default().submit_on_enter(false).setup(&mut vi);
             ReadLine::new(vi)
         },
     }

--- a/crates/scansion/src/lib.rs
+++ b/crates/scansion/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! fn main() -> Result<(), std::io::Error> {
 //!     let mut vi = VimMachine::<TerminalKey, ReadLineInfo>::empty();
-//!     VimBindings::default().submit_on_enter().setup(&mut vi);
+//!     VimBindings::default().submit_on_enter(false).setup(&mut vi);
 //!
 //!     let mut rl = ReadLine::new(vi)?;
 //!


### PR DESCRIPTION
Part of implementing ulyssa/iamb#686. I don't think this makes sense to add to emacs bindings and I don't know kakoune enough to say whether it is useful there.